### PR TITLE
remove GNU-specific usage for `sed` in shell example

### DIFF
--- a/examples/ex1.sh
+++ b/examples/ex1.sh
@@ -6,7 +6,7 @@ HOST="http://localhost:3000"
 echo "Connecting..."
 conn="$(curl -X POST $HOST/v1.0/connect)"
 echo $conn
-sessid="$(sed -r 's/\{"sessid":"([[:alnum:]_-]+)".+\}/\1/' <<< $"$conn")"
+sessid="$(sed 's/^{"sessid":"\([A-Za-z0-9_-]*\)".*}$/\1/' <<< $"$conn")"
 echo "SESSION ID $sessid"
 
 curl $OPTS -X POST $HOST/v1.0/request/blp/refdata/HistoricalData?sessid=$sessid --data @- <<EOF


### PR DESCRIPTION
This ensures that the shell example works with GNU and non-GNU `sed`.
