### PR TITLE
Use " instead of ' for response property names.

### DIFF
--- a/tslib/api-session.ts
+++ b/tslib/api-session.ts
@@ -91,7 +91,7 @@ export function makeHandler (): (req: OurRequest, res: OurResponse, next: Functi
                     if (needComma) {
                         chunk += ',';
                     }
-                    chunk += '\'data\':[';
+                    chunk += '"data":[';
                     needComma = false;
                 }
                 if (needComma) {


### PR DESCRIPTION
Make data uniform with the other properties in the response, which use ".
