### PR TITLE
Add logging for request body & client certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ SRCS_TS += $(wildcard lib/*.ts)
 
 SRCS_JS_FROM_TS += $(patsubst %.ts,%.js,$(SRCS_TS))
 
-TSC = tsc
+TSC := $(shell npm bin)/tsc
 TSC_COMMON = --module commonjs --target ES5 --sourceMap --noImplicitAny
 TS_TO_JS = $(TSC) $(TSC_COMMON)
 TSC_TARGET = .tsc.d
 
-TSLINT = tslint
+TSLINT := $(shell npm bin)/tslint
 TSLINT_TARGET = .tslint.d
 
 RM ?= rm -f

--- a/examples/cfg.json
+++ b/examples/cfg.json
@@ -13,9 +13,11 @@
     },
     "logging": {
         "stdout": true,
-        "stdoutLevel": "trace",
+        "stdoutLevel": "debug",
         "logfile": "blpapi-http.log",
-        "logfileLevel": "trace"
+        "logfileLevel": "trace",
+        "reqBody": true,
+        "clientDetail": true
     },
     "service": {
         "name": "blpapi-http",

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import bunyan = require('bunyan');
 import BAPI = require('./lib/blpapi-wrapper');
 import apiSession = require('./lib/api-session');
 import conf = require('./lib/config');
+import plugin = require('./lib/plugin');
 
 var logger: bunyan.Logger = bunyan.createLogger(conf.get('loggerOptions'));
 var session: BAPI.Session;
@@ -21,7 +22,7 @@ createSession()
     var server = restify.createServer(serverOptions);
 
     // Setup request logging
-    server.pre((req: restify.Request, res: restify.Response, next: restify.Next): any => {
+    server.pre(function pre(req: restify.Request, res: restify.Response, next: restify.Next): any {
         // Override request content-type so it is not mandatory for client
         req.headers['content-type'] = 'application/json';
         req.log.info({req: req}, 'Request received.');
@@ -40,6 +41,7 @@ createSession()
     server.use(restify.fullResponse());
     server.use(restify.throttle(conf.get('throttleOptions')));
     server.use(restify.requestLogger());
+    server.use(plugin.log());
 
     // Route
     server.post('/request/:ns/:svName/:reqName', onRequest);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -94,6 +94,18 @@ class Config {
                     format: String,
                     default: 'trace',
                     arg: 'logging-logfileLevel'
+                },
+                'reqBody': {
+                    doc: 'Boolean option to control whether to log request body',
+                    format: Boolean,
+                    default: false,
+                    arg: 'logging-reqBody'
+                },
+                'clientDetail': {
+                    doc: 'Boolean option to control whether to log client details',
+                    format: Boolean,
+                    default: false,
+                    arg: 'logging-clientDetail'
                 }
             },
             'service': {
@@ -138,10 +150,10 @@ class Config {
         Config.convictConf.validate();
 
         // Build options object
-        Config.buildOptions();
+        Config.initialize();
     })();
 
-    private static buildOptions(): void {
+    private static initialize(): void {
         // Bunyan logger options
         // Override default bunyan response serializer
         bunyan.stdSerializers['res'] = function(res) {
@@ -151,6 +163,13 @@ class Config {
             return {
                 statusCode: res.statusCode,
                 header: res._headers
+            };
+        };
+        // Add client cert serializer
+        bunyan.stdSerializers['cert'] = function(cert): any {
+            return cert && {
+                CN: cert.subject.CN,
+                fingerprint: cert.fingerprint
             };
         };
         var streams: {}[] = [{level: Config.convictConf.get('logging.logfileLevel'),

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -1,0 +1,35 @@
+import tls = require('tls');
+import apiSession = require('./api-session');
+import conf = require('./config');
+
+export = Plugin;
+
+class Plugin {
+
+    // Custom logging plugin.
+    // Log client cert details, request body, etc
+    public static log(): (req: apiSession.OurRequest,
+                          res: apiSession.OurResponse,
+                          next: Function ) => void {
+
+        return function log(req: apiSession.OurRequest,
+                            res: apiSession.OurResponse,
+                            next: Function ): void {
+            // Log client certificate details(only in https mode)
+            if (conf.get('https.enable') && conf.get('logging.clientDetail')) {
+                // Note: The doulbe casting is needed because union type is not available in ts 1.3
+                // TODO: Switch req.connection type definition to net.Socket|tls.ClearTextStream
+                // TODO: when ts 1.4.0 is officially released
+                req.log.debug(
+                  {cert: (<tls.ClearTextStream><any>req.connection).getPeerCertificate()});
+            }
+
+            // Log request body
+            if (conf.get('logging.reqBody')) {
+                req.log.debug({body: req.body});
+            }
+
+            return next();
+        };
+    }
+}


### PR DESCRIPTION
This change addresses the following issues(relate to issue #13 ):
- Add a plugin class for custom restify middleware. Right now there's only a log middleware for logging request body and client cert details.
- Use the dev dependency typescript compiler in the Make file.
- Update typescript compiler to 1.4.0 so we could leverage the union type definition.
