### PR TITLE
Update TypeScript and tslint dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ SRCS_TS += $(wildcard lib/*.ts)
 
 SRCS_JS_FROM_TS += $(patsubst %.ts,%.js,$(SRCS_TS))
 
-TSC := $(shell npm bin)/tsc
-TSC_COMMON = --module commonjs --target ES5 --sourceMap --noImplicitAny
+BIN_PREFIX := $(shell npm bin)
+TSC := $(addprefix $(BIN_PREFIX)/,tsc)
+TSC_COMMON = --module commonjs --target ES5 --sourceMap --noImplicitAny --noEmitOnError
 TS_TO_JS = $(TSC) $(TSC_COMMON)
-TSC_TARGET = .tsc.d
 
-TSLINT := $(shell npm bin)/tslint
+TSLINT := $(addprefix $(BIN_PREFIX)/,tslint)
 TSLINT_TARGET = .tslint.d
 
 RM ?= rm -f
@@ -23,7 +23,7 @@ TOUCH ?= touch
 
 all: typescript tslint
 
-typescript: $(SRCS_JS_FROM_TS) $(TSC_TARGET)
+typescript: $(SRCS_JS_FROM_TS)
 
 tslint: $(TSLINT_TARGET)
 
@@ -31,13 +31,11 @@ clean:
 	$(RM) $(SRCS_JS_FROM_TS) $(patsubst %.js,%.js.map,$(SRCS_JS_FROM_TS))
 	$(RM) $(TSC_TARGET) $(TSLINT_TARGET)
 
-$(TSLINT_TARGET): $(TSC_TARGET)
+$(TSLINT_TARGET): $(SRCS_TS)
 	@$(RM) $(TSLINT_TARGET)
 	$(TSLINT) $(foreach file,$(SRCS_TS),-f $(file))
 	@$(TOUCH) $(TSLINT_TARGET)
 
-$(TSC_TARGET) $(SRCS_JS_FROM_TS): $(SRCS_TS)
-	@$(RM) $(TSC_TARGET)
+$(SRCS_JS_FROM_TS): $(SRCS_TS)
 	$(QUIET_TSC) $(TS_TO_JS) $(TOP_LEVEL_TS_FILE)
-	@$(TOUCH) $(TSC_TARGET)
 

--- a/lib/api-session.ts
+++ b/lib/api-session.ts
@@ -49,7 +49,7 @@ export function makeHandler (): (req: OurRequest, res: OurResponse, next: Functi
 
         res.sendChunk = function ( data ): Promise<any> {
             var p = prepareSession();
-            return p.then(function() {
+            return p.then((): void => {
                 if (chunkIndex === 1) {
                     res.statusCode = 200;
                     if (needComma) {
@@ -68,7 +68,7 @@ export function makeHandler (): (req: OurRequest, res: OurResponse, next: Functi
 
         res.sendEnd = function(status, message): Promise<any> {
             var p = prepareSession();
-            return p.then(function() {
+            return p.then((): void => {
                 // If this is the only chunk, we can set the http status
                 if (chunkIndex === 1) {
                     res.statusCode = 200;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -11,7 +11,7 @@ class Config {
     private static otherConf: {[index: string]: any};
 
     // Private static constructor
-    private static _constructor = (() => {
+    private static _constructor = ((): void => {
         Config.otherConf = {};
 
         // Convict from file
@@ -156,7 +156,7 @@ class Config {
     private static initialize(): void {
         // Bunyan logger options
         // Override default bunyan response serializer
-        bunyan.stdSerializers['res'] = function(res) {
+        bunyan.stdSerializers['res'] = function(res): any {
             if (!res || !res.statusCode) {
                 return res;
             }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "devDependencies": {
     "tsd": "^0.5.7",
-    "tslint": "^1.0.1",
-    "typescript": "^1.3.0"
+    "tslint": "^1.2.0",
+    "typescript": "^1.4.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tslint.json
+++ b/tslint.json
@@ -31,6 +31,9 @@
         "radix": true,
         "semicolon": true,
         "triple-equals": true,
+        "typedef": [true,
+            "call-signature"
+        ],
         "use-strict": [true,
             "check-module"
         ],


### PR DESCRIPTION
This PR bumps the dependencies of [TypeScript](https://github.com/microsoft/typescript) to `1.4.1` and [tslint](https://github.com/palantir/tslint) to `1.2.0`.

The `Makefile` is now taking advantage of `tsc --noEmitOnError`, which simplified the `Makefile` to depend upon the generated `*.js` files as the only target.

Taking a similar approach to other languages that have type inference, `tslint.json` has been updated so that all call signatures require type definitions.  This works out well in understanding the contract of an API at a glance and relying upon type inference in the implementation,
