### PR TITLE
Update bluebird and convict dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "blpapi": "^0.1.14",
     "bluebird": "^2.8.2",
     "bunyan": "^1.2.3",
-    "convict": "^0.5.1",
+    "convict": "^0.6.1",
     "debug": "^2.1.0",
     "optimist": "^0.6.1",
     "restify": "^2.8.4"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "server.js",
   "dependencies": {
     "blpapi": "^0.1.14",
-    "bluebird": "^2.3.6",
+    "bluebird": "^2.8.2",
+    "bunyan": "^1.2.3",
     "convict": "^0.5.1",
     "debug": "^2.1.0",
     "optimist": "^0.6.1",
-    "restify": "^2.8.4",
-    "bunyan": "^1.2.3"
+    "restify": "^2.8.4"
   },
   "devDependencies": {
     "tsd": "^0.5.7",


### PR DESCRIPTION
Update [bluebird](https://github.com/petkaantonov/bluebird) and [convict](https://github.com/mozilla/node-convict) dependencies to the latest version.  There are various bug fixes and performance enhancements to pick up.
