### PR TITLE
restructure type definition files and directories

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-/// <reference path='typings/tsd.d.ts' />
+/// <reference path='typings/definitions.d.ts' />
 
 import restify = require('restify');
 import Promise = require('bluebird');

--- a/lib/api-session.ts
+++ b/lib/api-session.ts
@@ -1,4 +1,4 @@
-/// <reference path='../typings/tsd.d.ts' />
+/// <reference path='typings/definitions.d.ts' />
 
 import assert = require('assert');
 import http = require('http');

--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -1,4 +1,4 @@
-/// <reference path="../typings/tsd.d.ts" />
+/// <reference path='typings/definitions.d.ts' />
 'use strict';
 
 import assert = require('assert');

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,3 +1,5 @@
+/// <reference path='typings/definitions.d.ts' />
+
 import fs = require('fs');
 import path = require('path');
 import convict = require('convict');

--- a/lib/typings/blpapi.d.ts
+++ b/lib/typings/blpapi.d.ts
@@ -1,9 +1,4 @@
-// Type definitions for blpapi-node
-// Project: https://github.com/bloomberg/blpapi-node
-// Definitions by: Tzvetan Mikov <https://github.com/tmikov>
-// Definitions: https://github.com/borisyankov/DefinitelyTyped
-
-/// <reference path="../node/node.d.ts" />
+/// <reference path='definitions.d.ts' />
 
 declare module "blpapi" {
 

--- a/lib/typings/definitions.d.ts
+++ b/lib/typings/definitions.d.ts
@@ -1,0 +1,4 @@
+/// <reference path='../../typings/definitions.d.ts' />
+/// <reference path='blpapi.d.ts' />
+/// <reference path='optimist-override.d.ts' />
+/// <reference path='restify-override.d.ts' />

--- a/lib/typings/optimist-override.d.ts
+++ b/lib/typings/optimist-override.d.ts
@@ -1,0 +1,7 @@
+// Type definition overrides for optimist
+
+declare module "optimist" {
+    module optimist {
+        export var argv: any;
+    }
+}

--- a/lib/typings/restify-override.d.ts
+++ b/lib/typings/restify-override.d.ts
@@ -1,0 +1,7 @@
+// Type definition overrides for restify
+
+declare module "restify" {
+    // borisyankov/DefinitelyTyped#3546
+    export class UnsupportedMediaTypeError { constructor(message: any); }
+}
+

--- a/typings/definitions.d.ts
+++ b/typings/definitions.d.ts
@@ -1,0 +1,1 @@
+/// <reference path='tsd.d.ts' />

--- a/typings/node/node.d.ts
+++ b/typings/node/node.d.ts
@@ -273,7 +273,6 @@ declare module "http" {
     import events = require("events");
     import net = require("net");
     import stream = require("stream");
-    import tls = require("tls");
 
     export interface Server extends events.EventEmitter {
         listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server;
@@ -292,7 +291,7 @@ declare module "http" {
         setEncoding(encoding?: string): void;
         pause(): void;
         resume(): void;
-        connection: net.Socket|tls.ClearTextStream;
+        connection: net.Socket;
     }
     export interface ServerResponse extends events.EventEmitter, stream.Writable {
         // Extended base methods

--- a/typings/optimist/optimist.d.ts
+++ b/typings/optimist/optimist.d.ts
@@ -47,8 +47,6 @@ declare module "optimist" {
 		export interface Argv extends Object {
 			_: string[];
 		}
-
-		export var argv: any;
 	}
 
 	export = optimist;

--- a/typings/restify/restify.d.ts
+++ b/typings/restify/restify.d.ts
@@ -194,8 +194,6 @@ declare module "restify" {
   export class RequestThrottledError { constructor(message: any); }
   export class ResourceNotFoundError { constructor(message: any); }
   export class WrongAcceptError { constructor(message: any); }
-  export class UnsupportedMediaTypeError { constructor(message: any); }
-  export class RequestTimeoutError { constructor(message: any); }
 
   export function acceptParser(parser: any): RequestHandler;
   export function authorizationParser(): RequestHandler;

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="blpapi/blpapi.d.ts" />
 /// <reference path="bluebird/bluebird.d.ts" />
 /// <reference path="convict/convict.d.ts" />
 /// <reference path="bunyan/bunyan.d.ts" />


### PR DESCRIPTION
This change introduces a level of indirection for referencing type
definitions and a convention for extending/overriding definitions
provided by the [DefinitelyTyped](http://http://definitelytyped.org/)
project.

The primary motiviations for introducing another level of indirection
for referencing type definitions are:
1. Provide each `.ts` file stability for the `.d.ts` file it references.
2. The subdirectory `typings`, where the stable `.d.ts` reference is
   located, also serves as the directortory to place
   extensions/overrides to third-party type definitions.

The consequence is that each `.ts` files only needs to reference
`typings/definitions.d.ts`, which will remain stable in event of file
moves.

Additionally, overrides may be placed in the `typings` subdirectory and
need only to be referenced by `typings/definitions.d.ts`.
