### PR TITLE
expose `Subscription` as a class instead of an interface

### DIFF
--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -19,10 +19,33 @@ export interface RequestCallback {
     (err: Error, data?: any, isFinal?: boolean): void;
 }
 
-export interface Subscription extends events.EventEmitter {
+export class Subscription extends events.EventEmitter {
     security: string;
     fields: string[];
-    options?: any;
+    options: any = null;
+
+    constructor(security: string, fields: string[], options?: any) {
+        super();
+
+        this.security = security;
+        this.fields = fields;
+        if (3 === arguments.length) {
+            this.options = options;
+        }
+    }
+
+    private toJSON(): Object {
+        var result: { security: string; fields: string[]; options?: any; } = {
+            security: this.security,
+            fields: this.fields
+        };
+
+        if (null !== this.options) {
+            result.options = this.options;
+        }
+
+        return result;
+    }
 }
 
 export class BlpApiError implements Error {


### PR DESCRIPTION
When `interface Subscription` was exposed, callers could add their own
properties to the subscription object that would be passed-into the
blpapi wrapper.  This caused problems with the internal logging for
calls to `subscribe()` and `unsubscribe()` since additional properites
were being serialized.  To prevent this from happening, the wrapper now
exposes `Subscription` as a **class** and provides a `private toJSON()`
method for `JSON.stringify` to only serialize the properties that the
wrapper cares about for logging.
