### PR TITLE
Add subscription via websocket(socket.io & ws)

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -48,7 +48,7 @@ export function get(name: string): any
             env: 'BLPAPI_HTTP_PORT',
             arg: 'port'
         },
-        'expiration' : {
+        'expiration': {
             doc: 'Auto-expiration period of blpSession in seconds',
             format: 'integer',
             default: 5
@@ -149,6 +149,36 @@ export function get(name: string): any
                 format: 'integer',
                 default: 50,
                 arg: 'throttle-rate'
+            }
+        },
+        'websocket': {
+            'socket-io': {
+                'enable': {
+                    doc: 'Boolean option to control whether to run socket.io server',
+                    format: Boolean,
+                    default: true,
+                    arg: 'websocket-socket-io-enable'
+                },
+                'port': {
+                    doc: 'The socket io port to listen on',
+                    format: 'port',
+                    default: 3001,
+                    arg: 'websocket-socket-io-port'
+                },
+            },
+            'ws': {
+                'enable': {
+                    doc: 'Boolean option to control whether to run ws server',
+                    format: Boolean,
+                    default: true,
+                    arg: 'websocket-ws-enable'
+                },
+                'port': {
+                    doc: 'The ws port to listen on',
+                    format: 'port',
+                    default: 3002,
+                    arg: 'websocket-ws-port'
+                },
             }
         }
     });

--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -1,7 +1,7 @@
 /// <reference path='../typings/tsd.d.ts' />
 
-import Promise = require('bluebird');
 import restify = require('restify');
+import bunyan = require('bunyan');
 import BAPI = require('./blpapi-wrapper');
 
 export interface IOurRequest extends restify.Request {
@@ -13,4 +13,14 @@ export interface IOurResponse extends restify.Response {
     sendChunk?: (data: any) => Promise<void>;
     sendEnd?: (status: any, message: string) => Promise<void>;
     sendError?: (err: any, where: string, reason?: any) => Promise<void>;
+}
+
+export interface ISocket extends NodeJS.EventEmitter {
+    log: bunyan.Logger; // Add bunyan logger to socket
+    blpSession: BAPI.Session;  // Add blpSession to socket
+    isConnected(): boolean;
+    getIP(): string;
+    getCert(): any;
+    disconnect(): void;
+    send(name: string, ...args: any[]): void;
 }

--- a/lib/middleware/blp-session.ts
+++ b/lib/middleware/blp-session.ts
@@ -1,5 +1,6 @@
 /// <reference path='../../typings/tsd.d.ts' />
 
+import Promise = require('bluebird');
 import bunyan = require('bunyan');
 import restify = require('restify');
 import blpapi = require('../blpapi-wrapper');
@@ -8,10 +9,7 @@ import interfaces = require('../interface');
 
 // CONSTANTS
 var DEFAULT_ID = '__default__';
-var DEFAULT_SESSION_OPTIONS = {
-    serverHost: conf.get('api.host'),
-    serverPort: conf.get('api.port')
-};
+var DEFAULT_SESSION_OPTIONS = conf.get('sessionOptions');
 
 // GLOBALS
 var SESSION_STORE: {[index: string]: Promise<blpapi.Session>} = {};
@@ -55,5 +53,18 @@ export function getSession(req: interfaces.IOurRequest,
         }).catch((err: Error): void => {
             req.log.error(err, 'Error getting blpSession.');
             return next(new restify.InternalError(err.message));
+        });
+}
+
+export function getSocketSession(socket: interfaces.ISocket): Promise<interfaces.ISocket>
+{
+    return createSession(DEFAULT_ID)
+        .then((session: blpapi.Session): interfaces.ISocket => {
+            socket.log.debug('blpSession retrieved.');
+            socket.blpSession = session;
+            return socket;
+        }).catch((err: Error): any => {
+            socket.log.error(err, 'Error getting blpSession.');
+            throw err;
         });
 }

--- a/lib/subscription/subscription-store.ts
+++ b/lib/subscription/subscription-store.ts
@@ -1,0 +1,72 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import _ = require('lodash');
+import Subscription = require('./subscription');
+
+export = SubscriptionStore;
+
+class SubscriptionStore<T extends Subscription> {
+
+    protected subscriptions: {[key: number]: T} = {};
+
+    get size(): number {
+        return _.keys(this.subscriptions).length;
+    }
+
+    get(cid: number): T {
+        return this.has(cid) ? this.subscriptions[cid] : undefined;
+    }
+
+    getAll(): T[] {
+        return _.values(this.subscriptions);
+    }
+
+    add(subscription: T): boolean {
+        if (this.has(subscription.correlationId)) {
+            return false;
+        }
+        this.subscriptions[subscription.correlationId] = subscription;
+        return true;
+    }
+
+    has(value: number): boolean;
+    has(value: T): boolean;
+    has(value: any): boolean {
+        if (typeof value === 'number') {
+            return _.has(this.subscriptions, value);
+        }
+        else if (typeof value === 'object') {
+            return _.has(this.subscriptions, value.correlationId);
+        }
+        return false;
+    }
+
+    delete(value: number): boolean;
+    delete(value: T): boolean;
+    delete(value: any): boolean {
+        if (typeof value === 'number') {
+            if (!this.has(value)) {
+                return false;
+            }
+            delete this.subscriptions[value];
+            return true;
+        }
+        else if (typeof value === 'object') {
+            if (!this.has(value)) {
+                return false;
+            }
+            delete this.subscriptions[value.correlationId];
+            return true;
+        }
+        return false;
+    }
+
+    clear(): void {
+        _.forOwn(this.subscriptions, (sub: T,
+                                      key: string): void => {
+            sub.removeAllListeners();
+        });
+        this.subscriptions = {};
+    }
+
+}

--- a/lib/subscription/subscription.ts
+++ b/lib/subscription/subscription.ts
@@ -1,0 +1,19 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import BAPI = require('../blpapi-wrapper');
+
+export = Subscription;
+
+class Subscription extends BAPI.Subscription {
+
+    correlationId: number;
+
+    constructor(cid: number,
+                security: string,
+                fields: string[],
+                options?: any) {
+        super(security, fields, options);
+
+        this.correlationId = cid;
+    }
+}

--- a/lib/websocket/socket-event-emitter-adapter.ts
+++ b/lib/websocket/socket-event-emitter-adapter.ts
@@ -1,0 +1,60 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import assert = require('assert');
+import events = require('events');
+
+// TYPEDEF
+var EVENTEMITTERPROTOTYPE = events.EventEmitter.prototype;
+
+export = SocketEventEmitterAdapter;
+
+class SocketEventEmitterAdapter implements events.EventEmitter {
+    // DATA
+    private emitter: SocketIO.Socket;
+
+    // CREATORS
+    constructor(socket: SocketIO.Socket) {
+        this.emitter = socket;
+    }
+
+    // NodeJS.EventEmitter implement
+    addListener(event: string, listener: Function): SocketEventEmitterAdapter {
+        EVENTEMITTERPROTOTYPE.addListener.apply(this.emitter, arguments);
+        return this;
+    }
+
+    on(event: string, listener: Function): SocketEventEmitterAdapter {
+        EVENTEMITTERPROTOTYPE.on.apply(this.emitter, arguments);
+        return this;
+    }
+
+    once(event: string, listener: Function): SocketEventEmitterAdapter {
+        EVENTEMITTERPROTOTYPE.once.apply(this.emitter, arguments);
+        return this;
+    }
+
+    removeListener(event: string, listener: Function): SocketEventEmitterAdapter {
+        EVENTEMITTERPROTOTYPE.removeListener.apply(this.emitter, arguments);
+        return this;
+    }
+
+    removeAllListeners(event?: string): SocketEventEmitterAdapter {
+        EVENTEMITTERPROTOTYPE.removeAllListeners.apply(this.emitter, arguments);
+        return this;
+    }
+
+    setMaxListeners(n: number): void {
+        EVENTEMITTERPROTOTYPE.setMaxListeners.apply(this.emitter, arguments);
+    }
+
+    listeners(event: string): Function[] {
+        return EVENTEMITTERPROTOTYPE.listeners.apply(this.emitter, arguments);
+    }
+
+    emit(event: string, ...args: any[]): boolean {
+        // Note that we want to stub calls to 'emit' because SocketIO.Socket.emit is specialized
+        // and does not follow the the standard NodeJS.EventEmitter interface.
+        assert(false, '“emit” should not be called on SocketEventEmitterAdapter');
+        return false;
+    }
+}

--- a/lib/websocket/socket-io-wrapper.ts
+++ b/lib/websocket/socket-io-wrapper.ts
@@ -1,0 +1,47 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import bunyan = require('bunyan');
+import SocketIO = require('socket.io');
+import BAPI = require('../blpapi-wrapper');
+import Interface = require('../interface');
+import SocketEventEmitterAdapter = require('./socket-event-emitter-adapter');
+
+export = SocketIOWrapper;
+
+class SocketIOWrapper extends SocketEventEmitterAdapter implements Interface.ISocket {
+    private socket: SocketIO.Socket;
+    private _log: bunyan.Logger;
+    public blpSession: BAPI.Session;
+
+    constructor(s: SocketIO.Socket, l: bunyan.Logger) {
+        super(s);
+        this.socket = s;
+        this._log = l;
+    }
+
+    get log(): bunyan.Logger {
+        return this._log;
+    }
+
+    isConnected(): boolean {
+        return this.socket.connected;
+    }
+
+    getIP(): string {
+        return (<any>this.socket).handshake.headers['x-forwarded-for']
+               || (<any>this.socket).conn.remoteAddress;
+    }
+
+    getCert(): any {
+        return this.socket.request.connection.getPeerCertificate();
+    }
+
+    disconnect(): void {
+        this.socket.disconnect(true);
+    }
+
+    send(name: string, ...args: any[]): void {
+        this.socket.emit(name, args);
+    }
+
+}

--- a/lib/websocket/websocket-handler.ts
+++ b/lib/websocket/websocket-handler.ts
@@ -1,0 +1,250 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import _ = require('lodash');
+import Promise = require('bluebird');
+import bunyan = require('bunyan');
+import uuid = require('node-uuid');
+import SocketIO = require('socket.io');
+import webSocket = require('ws');
+import Subscription = require('../subscription/subscription');
+import SubscriptionStore = require('../subscription/subscription-store');
+import conf = require('../config');
+import Interface = require('../interface');
+import blpSession = require('../middleware/blp-session');
+import SocketIOWrapper = require('./socket-io-wrapper');
+import WSWrapper = require('./ws-wrapper');
+
+// GLOBAL
+var LOGGER: bunyan.Logger = bunyan.createLogger(conf.get('loggerOptions'));
+
+// PUBLIC FUNCTIONS
+export function sioOnConnect(s: SocketIO.Socket): void
+{
+    var socket: Interface.ISocket = new SocketIOWrapper(s, LOGGER.child({req_id: uuid.v4()}));
+    onConnect(socket);
+}
+
+export function wsOnConnect(s: webSocket): void
+{
+    var socket: Interface.ISocket = new WSWrapper(s, LOGGER.child({req_id: uuid.v4()}));
+    onConnect(socket);
+}
+
+// PRIVATE FUNCTIONS
+function onConnect(socket: Interface.ISocket): void
+{
+    initialize(socket)
+        .then(setup)
+        .catch((err: Error): any => {
+            socket.log.error(err);
+            if (socket.isConnected()) {
+                socket.send('err', { message: 'Unexpected error: ' + err.message });
+                socket.disconnect();
+            }
+        });
+}
+
+function initialize(socket: Interface.ISocket): Promise<Interface.ISocket>
+{
+    socket.log.info({Address: socket.getIP()}, 'Client connected.');
+    if (conf.get('https.enable') && conf.get('logging.clientDetail')) {
+        socket.log.debug({cert: socket.getCert()}, 'Client certificate.');
+    }
+
+    // Get blpSession
+    return blpSession.getSocketSession(socket);
+}
+
+function setup(socket: Interface.ISocket): void
+{
+    // Create subscriptions store
+    var activeSubscriptions = new SubscriptionStore<Subscription>();
+    var receivedSubscriptions = new SubscriptionStore<Subscription>();
+
+    // Clean up sockets for cases where the underlying session terminated unexpectedly
+    socket.blpSession.once('SessionTerminated', (): void => {
+        if (socket.isConnected()) {
+            socket.log.debug('blpSession terminated unexpectedly. Terminate socket.');
+            socket.send('err', { message: 'blpSession terminated unexpectedly.' });
+            socket.disconnect();
+        }
+    });
+
+    // Subscribe
+    socket.on('subscribe', (data: Object[]): void => {
+        socket.log.info('Subscribe request received');
+        // Log body if configured
+        if (conf.get('logging.reqBody')) {
+            socket.log.debug({body: data}, 'Subscribe body.');
+        }
+
+        // Validate input options
+        var subscriptions: Subscription[] = [];
+        if (!data.length) {
+            socket.log.debug('No valid subscriptions found.');
+            socket.send('err', { message: 'No valid subscriptions found.' });
+            return;
+        }
+        data.forEach((s: {'correlationId': number;
+                          'security': string;
+                          'fields': string[];
+                          'options'?: any }): void => {
+            // Check if all requests are valid
+            // The Subscribe request will proceed only if all subscriptions are valid
+            if (!_.has(s, 'correlationId') ||
+                !_.isNumber(s.correlationId) ||
+                !_.has(s, 'security') ||
+                !_.isString(s.security) ||
+                !_.has(s, 'fields') ||
+                !_.isArray(s.fields)) {
+                socket.log.debug('Invalid subscription option.');
+                socket.send('err', { message: 'Invalid subscription option.' });
+                return;
+            }
+            if (receivedSubscriptions.has(s.correlationId)) {
+                socket.log.debug('Correlation Id already exists.');
+                socket.send('err', { message: 'Correlation Id already exists.' });
+                return;
+            }
+
+            var sub = new Subscription(s.correlationId,
+                                       s.security,
+                                       s.fields,
+                                       s.options);
+            subscriptions.push(sub);
+            receivedSubscriptions.add(sub);
+
+            // Add event listener for each subscription
+            sub.on('data', (data: any): void => {
+                socket.log.debug({data: {cid: sub.correlationId, time: process.hrtime()}},
+                                'Data received');
+
+                // Emit the data
+                // TODO: Acknowledgement callback function?
+                socket.send('data', {'correlationId': sub.correlationId,
+                                     'data': data});
+                socket.log.info('Data sent');
+            });
+        });
+
+        // Subscribe user request through blpapi-wrapper
+        socket.blpSession.subscribe(subscriptions)
+            .then((): void => {
+                if (socket.isConnected()) {
+                    subscriptions.forEach((s: Subscription): void => {
+                        activeSubscriptions.add(s);
+                    });
+                    socket.log.debug('Subscribed');
+                    socket.send('subscribed');
+                } else { // Unsubscribe if socket already closed
+                    try {
+                        socket.blpSession.unsubscribe(subscriptions);
+                    } catch (ex) {
+                        socket.log.error(ex, 'Error Unsubscribing');
+                    }
+                    subscriptions.forEach((s: Subscription): void => {
+                        s.removeAllListeners();
+                        receivedSubscriptions.delete(s);
+                    });
+                    socket.log.debug('Unsubscribed all active subscriptions');
+                }
+            }).catch( (err: Error): void => {
+                socket.log.error(err, 'Error Subscribing');
+                subscriptions.forEach((s: Subscription): void => {
+                    s.removeAllListeners();
+                    receivedSubscriptions.delete(s);
+                });
+                if (socket.isConnected()) {
+                    socket.send('err', err);
+                }
+            });
+    });
+
+    // Unsubscribe
+    socket.on('unsubscribe', (data: { 'correlationIds': number[] }): void => {
+        socket.log.info('Unsubscribe request received');
+        // Log body if configured
+        if (conf.get('logging.reqBody')) {
+            socket.log.debug({body: data}, 'Unsubscribe body.');
+        }
+
+        if (!activeSubscriptions.size) {
+            socket.log.debug('No active subscriptions.');
+            socket.send('err', { message: 'No active subscriptions.' });
+            return;
+        }
+
+        var subscriptions: Subscription[] = [];
+
+        if (!data) {
+            // If no correlation Id specified
+            // the default behavior is to unsubscribe all active subscriptions
+            subscriptions = activeSubscriptions.getAll();
+        } else {
+            // If we do receive data object, first check if it is valid(empty list is INVALID)
+            if (!_.has(data, 'correlationIds') ||
+                !_.isArray(data.correlationIds) ||
+                !data.correlationIds.length) {
+                socket.log.debug('Invalid unsubscribe data received.');
+                socket.send('err', { message: 'Invalid unsubscribe data received.' });
+                return;
+            }
+            // Next, validate all correlation Ids
+            // Will error if any invalid correlation Id received
+            var isAllValid = true;
+            _.uniq(data.correlationIds).forEach((cid: number): boolean => {
+                if (activeSubscriptions.has(cid)) {
+                    subscriptions.push(activeSubscriptions.get(cid));
+                } else {
+                    isAllValid = false;
+                    socket.log.debug('Invalid correlation Id ' + cid + ' received.');
+                    socket.send('err', { message: 'Invalid correlation Id ' + cid + ' received.' });
+                    return false;
+                }
+            });
+            if (!isAllValid) {
+                return;
+            }
+        }
+
+        try {
+            socket.blpSession.unsubscribe(subscriptions);
+        } catch (ex) {
+            socket.log.error(ex, 'Error Unsubscribing');
+            socket.send('err', { message: 'error unsubscribing:' + ex});
+            return;
+        }
+        subscriptions.forEach((s: Subscription): void => {
+            s.removeAllListeners();
+            activeSubscriptions.delete(s);
+            receivedSubscriptions.delete(s);
+        });
+        receivedSubscriptions.size
+            ? socket.send('unsubscribed')
+            : socket.send('unsubscribed all');
+        socket.log.debug({activeSubscriptions: activeSubscriptions.size}, 'Unsubscribed.');
+    });
+
+    // Disconnect
+    socket.on('disconnect', (): void => {
+        // Unsubscribe all active subscriptions
+        if (activeSubscriptions.size) {
+            var subscriptions: Subscription[] = activeSubscriptions.getAll();
+            try {
+                socket.blpSession.unsubscribe(subscriptions);
+            } catch (ex) {
+                socket.log.error(ex, 'Error Unsubscribing');
+            }
+            subscriptions.forEach((s: Subscription): void => {
+                s.removeAllListeners();
+                activeSubscriptions.delete(s);
+                receivedSubscriptions.delete(s);
+            });
+            socket.log.debug('Unsubscribed all active subscriptions');
+        }
+        socket.log.info('Client disconnected.');
+    });
+
+    // Complete server setup
+    socket.send('connected');
+}

--- a/lib/websocket/ws-wrapper.ts
+++ b/lib/websocket/ws-wrapper.ts
@@ -1,0 +1,72 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import events = require('events');
+import _ = require('lodash');
+import bunyan = require('bunyan');
+import webSocket = require('ws');
+import BAPI = require('../blpapi-wrapper');
+import Interface = require('../interface');
+
+export = WSWrapper;
+
+class WSWrapper extends events.EventEmitter implements Interface.ISocket {
+    private socket: webSocket;
+    private _log: bunyan.Logger;
+    public blpSession: BAPI.Session;
+
+    constructor(s: webSocket, l: bunyan.Logger) {
+        super();
+        this.socket = s;
+        this._log = l;
+
+        this.socket.on('message', (message: string): void => {
+            var obj: any;
+            try {
+                obj = JSON.parse(message);
+            } catch (ex) {
+                this.log.debug('error parsing message object:', ex);
+                this.send('err', ex);
+                return;
+            }
+
+            if (!_.has(obj, 'type') || !_.isString(obj.type)) {
+                this.log.debug('Invalid message type received.');
+                this.send('err', { message: 'Invalid message type received.'});
+                return;
+            }
+
+            if (obj.type !== 'disconnect') {
+                this.emit(obj.type, obj.data);
+            }
+        });
+
+        this.socket.on('close', (): void => {
+            this.emit('disconnect');
+        });
+    }
+
+    get log(): bunyan.Logger {
+        return this._log;
+    }
+
+    isConnected(): boolean {
+        return this.socket.readyState === webSocket.OPEN;
+    }
+
+    getIP(): string {
+        return this.socket.upgradeReq.headers['x-forwarded-for']
+               || this.socket.upgradeReq.connection.remoteAddress;
+    }
+
+    getCert(): any {
+        return (<any>this.socket).upgradeReq.connection.getPeerCertificate();
+    }
+
+    disconnect(): void {
+        this.socket.close();
+    }
+
+    send(name: string, ...args: any[]): void {
+        this.socket.send(JSON.stringify({type: name, data: args}));
+    }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "debug": "^2.1.0",
     "lodash": "^2.4.1",
     "optimist": "^0.6.1",
-    "restify": "^2.8.4"
+    "restify": "^2.8.4",
+    "socket.io": "^1.2.1",
+    "ws": "^0.6.4",
+    "node-uuid": "^1.4.2"
   },
   "devDependencies": {
     "tsd": "^0.5.7",

--- a/test/testSocketIO.js
+++ b/test/testSocketIO.js
@@ -1,0 +1,90 @@
+var io = require('socket.io-client');
+var fs = require('fs');
+var path = require('path');
+var cluster = require('cluster');
+
+var host = 'https://localhost:3001';
+var ns = '/subscription';
+var url = host + ns;
+var caFile = path.resolve(__dirname, '../keys/bloomberg-ca-crt.pem');
+var keyFile = path.resolve(__dirname, '../keys/client-key.pem');
+var certFile = path.resolve(__dirname, '../keys/client-crt.pem');
+var opt = {
+                cert: fs.readFileSync(certFile),
+                key: fs.readFileSync(keyFile),
+                ca: fs.readFileSync(caFile),
+                rejectUnauthorized: false,
+                reconnection: false
+          };
+var NUM = Infinity;
+var NUM_CLIENT = 1;
+var PRINT_OUTPUT = false;
+
+// Main
+if (cluster.isMaster) {
+    for (var i = 0; i < NUM_CLIENT; i++) {
+      cluster.fork();
+    }
+
+    cluster.on('online', function(worker) {
+        console.log('Worker ' + worker.process.pid + ' is online.');
+    });
+
+    cluster.on('exit', function(worker, code, signal) {
+        console.log('worker ' + worker.process.pid + ' died.');
+    });
+} else {
+    socketSubscription(cluster.worker.id);
+}
+
+function socketSubscription(clientId) {
+    var counter = 0;
+    console.log('Client Id: ' + clientId + '. Start testing.');
+
+    var socket = io.connect(url, opt);
+
+    socket.on('connected', function () {
+        counter = 0;
+        console.log('Connected' + '. Client Id: ' + clientId);
+        socket.emit('subscribe',
+                    [
+                        { security: 'AAPL US Equity', correlationId: 0, fields: ['LAST_PRICE'] }
+                        //{ security: 'GOOG US Equity', correlationId: 1, fields: ['LAST_PRICE'] }
+                    ]
+        );
+    });
+
+    socket.on('data', function (data) {
+        console.log('Data Count: ' + counter++ + '. Client Id: ' + clientId);
+        if (PRINT_OUTPUT) {
+            console.log(data);  
+        }
+        if (counter === NUM) {
+            //socket.emit('unsubscribe', { correlationIds: [0, 1] });
+            socket.emit('unsubscribe');
+        }
+    });
+
+    socket.on('err', function (data) {
+        console.log(data);
+    });
+
+    socket.on('subscribed', function () {
+        console.log('Subscribed' + '. Client Id: ' + clientId);
+    });
+
+    socket.on('unsubscribed', function () {
+        console.log('Unsubscribed' + '. Client Id: ' + clientId);
+    });
+
+    socket.on('unsubscribed all', function () {
+        console.log('Unsubscribed all' + '. Client Id: ' + clientId);
+        socket.disconnect();
+        process.exit();
+    });
+
+    socket.on('disconnect', function() {
+        console.log('Socket Disconnected.' + '. Client Id: ' + clientId);
+        process.exit();
+    });
+}

--- a/test/testws.js
+++ b/test/testws.js
@@ -1,0 +1,105 @@
+var WebSocket = require('ws');
+var fs = require('fs');
+var path = require('path');
+var cluster = require('cluster');
+
+var host = 'wss://localhost:3002';
+var caFile = path.resolve(__dirname, '../keys/bloomberg-ca-crt.pem');
+var keyFile = path.resolve(__dirname, '../keys/client-key.pem');
+var certFile = path.resolve(__dirname, '../keys/client-crt.pem');
+var opt = {
+                cert: fs.readFileSync(certFile),
+                key: fs.readFileSync(keyFile),
+                ca: fs.readFileSync(caFile),
+                rejectUnauthorized: false
+          };
+var NUM = Infinity;
+var NUM_CLIENT = 1;
+var PRINT_OUTPUT = false;
+
+// Main
+if (cluster.isMaster) {
+    for (var i = 0; i < NUM_CLIENT; i++) {
+      cluster.fork();
+    }
+
+    cluster.on('online', function(worker) {
+        console.log('Worker ' + worker.process.pid + ' is online.');
+    });
+
+    cluster.on('exit', function(worker, code, signal) {
+        console.log('worker ' + worker.process.pid + ' died.');
+    });
+} else {
+    socketSubscription(cluster.worker.id);
+}
+
+function socketSubscription(clientId) {
+    var counter = 0;
+    console.log('Client Id: ' + clientId + '. Start testing.');
+
+    var socket = new WebSocket(host, opt);
+
+    function prepare(type, data) {
+            return JSON.stringify({'type': type, 'data': data});
+    }
+
+    socket.on('message', function(message) {
+        var obj = JSON.parse(message);
+
+        switch(obj.type) {
+            case 'connected': {
+                counter = 0;
+                console.log('Socket Connected. Client Id: ' + clientId);
+                socket.send(prepare('subscribe',
+                            [
+                                { security: 'AAPL US Equity', correlationId: 0, fields: ['LAST_PRICE'] }
+                                //{ security: 'GOOG US Equity', correlationId: 1, fields: ['LAST_PRICE'] }
+                            ]
+                ));
+                break;
+            }
+            case 'data': {
+                console.log('Data Count: ' + counter++ + '. Client Id: ' + clientId);
+                if (PRINT_OUTPUT) {
+                    console.log(obj.data);
+                }
+
+                if (counter === NUM) {
+                    //socket.emit('unsubscribe', { correlationIds: [0, 1] });
+                    socket.send(prepare('unsubscribe'))
+                }
+                break;
+            }
+            case 'subscribed': {
+                console.log('Subscribed. Client Id: ' + clientId);
+                break;
+            }
+            case 'unsubscribed': {
+                console.log('Unsubscribed. Client Id: ' + clientId);
+                break;
+            }
+            case 'unsubscribed all': {
+                console.log('Unsubscribed all. Client Id: ' + clientId);
+                socket.close();
+                process.exit();
+                break;
+            }
+            case 'err': {
+                console.log('Error received: ');
+                console.log(obj.data);
+                console.log('. Client Id: ' + clientId)
+                break;
+            }
+            default: {
+                console.log('Invalid message type: ' + obj.type + '. Client Id: ' + clientId);
+                socket.close();
+            }
+        }
+    });
+
+    socket.on('close', function() {
+        console.log('Socket Disconnected. Client Id: ' + clientId);
+        process.exit();
+    });
+}

--- a/tsd.json
+++ b/tsd.json
@@ -28,6 +28,15 @@
     },
     "restify/restify.d.ts": {
       "commit": "b3324f69165309a3ea2bd02fd10e97841bf07c83"
+    },
+    "socket.io/socket.io.d.ts": {
+      "commit": "b3324f69165309a3ea2bd02fd10e97841bf07c83"
+    },
+    "ws/ws.d.ts": {
+      "commit": "b3324f69165309a3ea2bd02fd10e97841bf07c83"
+    },
+    "node-uuid/node-uuid.d.ts": {
+      "commit": "b3324f69165309a3ea2bd02fd10e97841bf07c83"
     }
   }
 }

--- a/typings/node-uuid/node-uuid.d.ts
+++ b/typings/node-uuid/node-uuid.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for node-uuid.js
+// Project: https://github.com/broofa/node-uuid
+// Definitions by: Jeff May <https://github.com/jeffmay>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+interface UUIDOptions {
+
+    /**
+     * Node id as Array of 6 bytes (per 4.1.6).
+     * Default: Randomly generated ID. See note 1.
+     */
+    node: any[]
+
+    /**
+     * (Number between 0 - 0x3fff) RFC clock sequence.
+     * Default: An internally maintained clockseq is used.
+     */
+    clockseq: number
+
+    /**
+     * (Number | Date) Time in milliseconds since unix Epoch.
+     * Default: The current time is used.
+     */
+    msecs: any
+
+    /**
+     * (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if msecs is unspecified.
+     * Default: internal uuid counter is used, as per 4.2.1.2.
+     */
+    nsecs: number
+}
+
+interface UUID {
+    v1(options?: UUIDOptions, buffer?: number[], offset?: number): string
+    v1(options?: UUIDOptions, buffer?: Buffer, offset?: number): string
+
+    v2(options?: UUIDOptions, buffer?: number[], offset?: number): string
+    v2(options?: UUIDOptions, buffer?: Buffer, offset?: number): string
+
+    v3(options?: UUIDOptions, buffer?: number[], offset?: number): string
+    v3(options?: UUIDOptions, buffer?: Buffer, offset?: number): string
+
+    v4(options?: UUIDOptions, buffer?: number[], offset?: number): string
+    v4(options?: UUIDOptions, buffer?: Buffer, offset?: number): string
+}
+
+declare module "node-uuid" {
+    var uuid: UUID;
+    export = uuid;
+}

--- a/typings/restify/restify.d.ts
+++ b/typings/restify/restify.d.ts
@@ -95,6 +95,7 @@ declare module "restify" {
     listen(... args: any[]): any;
     close(... args: any[]): any;
     pre(routeCallBack: RequestHandler): any;
+    server: http.Server;
 
   }
 

--- a/typings/socket.io/socket.io.d.ts
+++ b/typings/socket.io/socket.io.d.ts
@@ -1,0 +1,78 @@
+// Type definitions for socket.io 1.2.0
+// Project: http://socket.io/
+// Definitions by: PROGRE <https://github.com/progre/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+///<reference path='../node/node.d.ts' />
+
+declare module 'socket.io' {
+    var server: SocketIOStatic;
+
+    export = server;
+}
+
+interface SocketIOStatic {
+    (): SocketIO.Server;
+    (srv: any, opts?: any): SocketIO.Server;
+    (port: number, opts?: any): SocketIO.Server;
+    (opts: any): SocketIO.Server;
+
+    listen: SocketIOStatic;
+}
+
+declare module SocketIO {
+    interface Server {
+        serveClient(v: boolean): Server;
+        path(v: string): Server;
+        adapter(v: any): Server;
+        origins(v: string): Server;
+        sockets: Namespace;
+        attach(srv: any, opts?: any): Server;
+        attach(port: number, opts?: any): Server;
+        listen(srv: any, opts?: any): Server;
+        listen(port: number, opts?: any): Server;
+        bind(srv: any): Server;
+        onconnection(socket: any): Server;
+        of(nsp: string): Namespace;
+        emit(name: string, ...args: any[]): Socket;
+        use(fn: Function): Namespace;
+
+        on(event: 'connection', listener: (socket: Socket) => void): any;
+        on(event: 'connect', listener: (socket: Socket) => void): any;
+        on(event: string, listener: Function): any;
+    }
+
+    interface Namespace extends NodeJS.EventEmitter {
+        name: string;
+        connected: { [id: number]: Socket };
+        use(fn: Function): Namespace
+
+        on(event: 'connection', listener: (socket: Socket) => void): any;
+        on(event: 'connect', listener: (socket: Socket) => void): any;
+        on(event: string, listener: Function): any;
+    }
+
+    interface Socket {
+        rooms: string[];
+        client: Client;
+        conn: Socket;
+        request: any;
+        id: string;
+        emit(name: string, ...args: any[]): Socket;
+        join(name: string, fn?: Function): Socket;
+        leave(name: string, fn?: Function): Socket;
+        to(room: string): Socket;
+        in(room: string): Socket;
+
+        on(event: string, listener: Function): any;
+        broadcast: Socket;
+        volatile: Socket;
+        connected: boolean;
+        disconnect(close: boolean): Socket;
+    }
+
+    interface Client {
+        conn: any;
+        request: any;
+    }
+}

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -7,3 +7,6 @@
 /// <reference path="debug/debug.d.ts" />
 /// <reference path="optimist/optimist.d.ts" />
 /// <reference path="restify/restify.d.ts" />
+/// <reference path="socket.io/socket.io.d.ts" />
+/// <reference path="ws/ws.d.ts" />
+/// <reference path="node-uuid/node-uuid.d.ts" />

--- a/typings/ws/ws.d.ts
+++ b/typings/ws/ws.d.ts
@@ -1,0 +1,136 @@
+// Type definitions for ws
+// Project: https://github.com/einaros/ws
+// Definitions by: Paul Loyd <https://github.com/loyd>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../node/node.d.ts" />
+
+declare module "ws" {
+    import events = require('events');
+    import http   = require('http');
+    import net    = require('net');
+
+    class WebSocket extends events.EventEmitter {
+        static CONNECTING: number;
+        static OPEN: number;
+        static CLOSING: number;
+        static CLOSED: number;
+
+        bytesReceived: number;
+        readyState: number;
+        protocolVersion: string;
+        url: string;
+        supports: any;
+        upgradeReq: http.ServerRequest;
+
+        CONNECTING: number;
+        OPEN: number;
+        CLOSING: number;
+        CLOSED: number;
+
+        onopen: (event: {target: WebSocket}) => void;
+        onerror: (err: Error) => void;
+        onclose: (event: {wasClean: boolean; code: number; reason: string; target: WebSocket}) => void;
+        onmessage: (event: {data: any; type: string; target: WebSocket}) => void;
+
+        constructor(address: string, options?: {
+            protocol?: string;
+            agent?: http.Agent;
+            headers?: {[key: string]: string};
+            protocolVersion?: any;
+            host?: string;
+            origin?: string;
+            pfx?: any;
+            key?: any;
+            passphrase?: string;
+            cert?: any;
+            ca?: any[];
+            ciphers?: string;
+            rejectUnauthorized?: boolean;
+        });
+
+        close(code?: number, data?: any): void;
+        pause(): void;
+        resume(): void;
+        ping(data?: any, options?: {mask?: boolean; binary?: boolean}, dontFail?: boolean): void;
+        pong(data?: any, options?: {mask?: boolean; binary?: boolean}, dontFail?: boolean): void;
+        send(data: any, cb?: (err: Error) => void): void;
+        send(data: any, options: {mask?: boolean; binary?: boolean}, cb?: (err: Error) => void): void;
+        stream(options: {mask?: boolean; binary?: boolean}, cb?: (err: Error, final: boolean) => void): void;
+        stream(cb?: (err: Error, final: boolean) => void): void;
+        terminate(): void;
+
+        // HTML5 WebSocket events
+        addEventListener(method: 'message', cb?: (event: {data: any; type: string; target: WebSocket}) => void): void;
+        addEventListener(method: 'close', cb?: (event: {wasClean: boolean; code: number;
+                                                        reason: string; target: WebSocket}) => void): void;
+        addEventListener(method: 'error', cb?: (err: Error) => void): void;
+        addEventListener(method: 'open', cb?: (event: {target: WebSocket}) => void): void;
+        addEventListener(method: string, listener?: () => void): void;
+
+        // Events
+        on(event: 'error', cb: (err: Error) => void): WebSocket;
+        on(event: 'close', cb: (code: number, message: string) => void): WebSocket;
+        on(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        on(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        on(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        on(event: 'open', cb: () => void): WebSocket;
+        on(event: string, listener: () => void): WebSocket;
+        
+        addListener(event: 'error', cb: (err: Error) => void): WebSocket;
+        addListener(event: 'close', cb: (code: number, message: string) => void): WebSocket;
+        addListener(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        addListener(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        addListener(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        addListener(event: 'open', cb: () => void): WebSocket;
+        addListener(event: string, listener: () => void): WebSocket;
+    }
+
+    module WebSocket {
+        export interface IServerOptions {
+            host?: string;
+            port?: number;
+            server?: http.Server;
+            verifyClient?: {
+                (info: {origin: string; secure: boolean; req: http.ServerRequest}): boolean;
+                (info: {origin: string; secure: boolean; req: http.ServerRequest},
+                                                 callback: (res: boolean) => void): void;
+            };
+            handleProtocols?: any;
+            path?: string;
+            noServer?: boolean;
+            disableHixie?: boolean;
+            clientTracking?: boolean;
+        }
+
+        export class Server extends events.EventEmitter {
+            options: IServerOptions;
+            path: string;
+            clients: WebSocket[];
+
+            constructor(options?: IServerOptions, callback?: Function);
+
+            close(): void;
+            handleUpgrade(request: http.ServerRequest, socket: net.Socket,
+                          upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
+
+            // Events
+            on(event: 'error', cb: (err: Error) => void): Server;
+            on(event: 'headers', cb: (headers: string[]) => void): Server;
+            on(event: 'connection', cb: (client: WebSocket) => void): Server;
+            on(event: string, listener: () => void): Server;
+            
+            addListener(event: 'error', cb: (err: Error) => void): Server;
+            addListener(event: 'headers', cb: (headers: string[]) => void): Server;
+            addListener(event: 'connection', cb: (client: WebSocket) => void): Server;
+            addListener(event: string, listener: () => void): Server;
+        }
+
+        export function createServer(options?: IServerOptions,
+            connectionListener?: (client: WebSocket) => void): Server;
+        export function connect(address: string, openListener?: Function): void;
+        export function createConnection(address: string, openListener?: Function): void;
+    }
+
+    export = WebSocket;
+}


### PR DESCRIPTION
This PR add subscription functionality to blpapi-http via websocket(`socket.io` & `ws`).

Some implementation notes:
- Create a common interface `ISocket` and two wrapper classes `socket-io-wrapper.ts` & `ws-wrapper.ts`. This unify the interfaces exposed by two libraries and enable us to create a single business handling code `websocket-handler.ts`.
- `subscription-sotre.ts` use generics to enable child class supply data item types.
