### PR TITLE
lint whitespace around type declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ TSC_COMMON = --module commonjs --target ES5 --sourceMap --noImplicitAny --noEmit
 TS_TO_JS = $(TSC) $(TSC_COMMON)
 
 TSLINT := $(addprefix $(BIN_PREFIX)/,tslint)
+TSLINT_CONFIG := tslint.json
 TSLINT_TARGET = .tslint.d
 
 RM ?= rm -f
@@ -31,7 +32,7 @@ clean:
 	$(RM) $(SRCS_JS_FROM_TS) $(patsubst %.js,%.js.map,$(SRCS_JS_FROM_TS))
 	$(RM) $(TSC_TARGET) $(TSLINT_TARGET)
 
-$(TSLINT_TARGET): $(SRCS_TS)
+$(TSLINT_TARGET): $(SRCS_TS) $(TSLINT_CONFIG)
 	@$(RM) $(TSLINT_TARGET)
 	$(TSLINT) $(foreach file,$(SRCS_TS),-f $(file))
 	@$(TOUCH) $(TSLINT_TARGET)

--- a/lib/middleware/request-handler.ts
+++ b/lib/middleware/request-handler.ts
@@ -112,9 +112,9 @@ export function onRequest(req: Interface.IOurRequest,
         return next(new restify.InternalError('Error not find blpSession.'));
     }
 
-    (() : Promise<any> => {
-        return (new Promise<any>((resolve : () => void,
-                                  reject : (error : any) => void) : void => {
+    ((): Promise<any> => {
+        return (new Promise<any>((resolve: () => void,
+                                  reject: (error: any) => void): void => {
             req.blpSession.request('//' + req.params.ns + '/' + req.params.svName,
                 req.params.reqName,
                 req.body,

--- a/tslint.json
+++ b/tslint.json
@@ -34,6 +34,13 @@
         "typedef": [true,
             "call-signature"
         ],
+        "typedef-whitespace": [true, {
+            "call-signature": "nospace",
+            "index-signature": "nospace",
+            "parameter": "nospace",
+            "property-declaration": "nospace",
+            "variable-declaration": "nospace"
+        }],
         "use-strict": [true,
             "check-module"
         ],


### PR DESCRIPTION
This change adds lint checks to ensure that there is no space before `:`
    for type declarations.  The `Makefile` has been updated so that
    `tslint.json` is a prerequisite for the `tslint` target.  Also, any
    affected `.ts` files have been updated accordingly.
