### PR TITLE
Add note about OSX 'curl' incompatibility to examples.

### DIFF
--- a/examples/shell/FieldInfo.sh
+++ b/examples/shell/FieldInfo.sh
@@ -2,6 +2,10 @@
 
 # usage: ./FieldInfo.sh <request.json>
 
+# NOTE: This example program currently fails on Mac OSX 10.9 or later, due to the inability
+# of 'curl' supplied in OSX to accept certificates and keys through command-line arguments.
+# A workaround is to use an alternate build of 'curl' (from Homebrew or MacPorts).
+
 if [ "$#" -ne 1 ]; then
 	echo "Missing Field Info JSON"
 	exit 1

--- a/examples/shell/HistoricalDataRequest.sh
+++ b/examples/shell/HistoricalDataRequest.sh
@@ -2,6 +2,10 @@
 
 # usage: ./HistoricalDataRequest.sh <request.json>
 
+# NOTE: This example program currently fails on Mac OSX 10.9 or later, due to the inability
+# of 'curl' supplied in OSX to accept certificates and keys through command-line arguments.
+# A workaround is to use an alternate build of 'curl' (from Homebrew or MacPorts).
+
 if [ "$#" -ne 1 ]; then
 	echo "Missing Historical Data Request JSON"
 	exit 1

--- a/examples/shell/ReferenceData.sh
+++ b/examples/shell/ReferenceData.sh
@@ -2,6 +2,10 @@
 
 # usage: ./ReferenceData.sh <request.json>
 
+# NOTE: This example program currently fails on Mac OSX 10.9 or later, due to the inability
+# of 'curl' supplied in OSX to accept certificates and keys through command-line arguments.
+# A workaround is to use an alternate build of 'curl' (from Homebrew or MacPorts).
+
 if [ "$#" -ne 1 ]; then
 	echo "Missing Reference Data JSON"
 	exit 1


### PR DESCRIPTION
Add a notice to the 'curl'-based examples about the current incompatibility with 'curl' provided by OSX 10.9+.
