### PR TITLE
Upgrade tslint to 2.1.0

### DIFF
--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -35,11 +35,13 @@ export class Subscription extends events.EventEmitter {
     }
 
     private toJSON(): Object {
+        // bug in tslint 2.1.0(issue 292). Temp disable it.
+        /* tslint:disable variables-before-functions */
         var result: { security: string; fields: string[]; options?: any; } = {
             security: this.security,
             fields: this.fields
         };
-
+        /* tslint:enable */
         if (null !== this.options) {
             result.options = this.options;
         }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "tsd": "^0.5.7",
-    "tslint": "^1.2.0",
+    "tslint": "^2.1.0",
     "typescript": "^1.4.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR upgrades `tslint` to version 2.1.0. 

We found a bug with tslint(palantir/tslint#292) that prevents us doing object literals. We have to temporarily disable this check for our one usage, but will remove it once tslint fix the issue and bump up the version.
