### PR TITLE
add more tslint checks

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -191,7 +191,7 @@ export function get(name: string): any
     // Build options object
     // Bunyan logger options
     // Override default bunyan response serializer
-    bunyan.stdSerializers['res'] = function(res): any {
+    bunyan.stdSerializers['res'] = function(res: any): any {
         if (!res || !res.statusCode) {
             return res;
         }
@@ -201,7 +201,7 @@ export function get(name: string): any
         };
     };
     // Add client cert serializer
-    bunyan.stdSerializers['cert'] = function(cert): any {
+    bunyan.stdSerializers['cert'] = function(cert: any): any {
         return cert && {
             CN: cert.subject.CN,
             fingerprint: cert.fingerprint

--- a/lib/middleware/request-handler.ts
+++ b/lib/middleware/request-handler.ts
@@ -87,7 +87,7 @@ export function elevateRequest (req: Interface.IOurRequest,
         });
     };
 
-    res.sendError = function(err, where, reason): Promise<void> {
+    res.sendError = function(err: any, where: string, reason: any): Promise<void> {
         var status: { source: string; category: string; errorCode: number};
         var r = err.data && err.data.reason;
         if (r) {

--- a/tslint.json
+++ b/tslint.json
@@ -1,12 +1,15 @@
 {
     "rules": {
+        "class-name": true,
         "comment-format": {
             "check-space":     true,
             "check-lowercase": true
         },
         "curly": true,
         "eofline": true,
+        "forin": true,
         "indent": [true, 4],
+        "interface-name": true,
         "max-line-length": [true, 100],
         "member-ordering": [true,
             "static-before-instance",
@@ -21,8 +24,10 @@
         "no-eval": true,
         "no-trailing-whitespace": true,
         "no-unreachable": true,
+        "no-unused-expression": true,
         "no-unused-variables": true,
         "no-use-before-declare": true,
+        "no-var-requires": true,
         "one-line": [true,
             "check-catch",
             "check-whitespace"
@@ -32,7 +37,10 @@
         "semicolon": true,
         "triple-equals": true,
         "typedef": [true,
-            "call-signature"
+            "call-signature",
+            "parameter",
+            "property-declaration",
+            "member-variable-declaration"
         ],
         "typedef-whitespace": [true, {
             "call-signature": "nospace",


### PR DESCRIPTION
- enforece PascalCased class names
- enforece properly checks when using `for ... in` constructs
- interfaces names must begin with capital `I`
- no unused expressions (i.e., expressions that contain side-effects)
- enforce type definitions in function parameters, properties for
  interface declarations, and member variable declarations

Affected files by the added checks have been updated appropriately.
