### PR TITLE
Added Instrument lookup

### DIFF
--- a/examples/json/InstrumentLookup/InstrumentLookup.json
+++ b/examples/json/InstrumentLookup/InstrumentLookup.json
@@ -1,0 +1,6 @@
+{
+    "query": "IBM",
+    "yellowKeyFilter": "YK_FILTER_CORP",
+    "languageOverride": "LANG_OVERRIDE_NONE",
+    "maxResults": 10
+}

--- a/examples/shell/InstrumentLookup.sh
+++ b/examples/shell/InstrumentLookup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# usage: ./InstrumentLookup.sh <request.json>
+
+if [ "$#" -ne 1 ]; then
+	echo "Missing Instrument Lookup JSON"
+	exit 1
+fi
+
+REQUEST="$1"
+
+curl -v -X POST "https://http-api.openbloomberg.com/request/blp/instruments/InstrumentLookup"  \
+     --cacert bloomberg.crt \
+     --cert   client.crt    \
+     --key    client.key    \
+     --data @"$REQUEST"

--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -71,13 +71,23 @@ var EVENT_TYPE = {
   , PARTIAL_RESPONSE: 'PARTIAL_RESPONSE'
 };
 
+// Map of HTTP request names to the BLAPI request and response names.
+var NAME_MAP: { [s: string]: { reqName: string; resName: string; } } = {
+    'FieldInfo':        { reqName: 'FieldInfoRequest',
+                          resName: 'fieldResponse' },
+    'FieldSearch':      { reqName: 'FieldInfoRequest',
+                          resName: 'fieldResponse' },
+    'InstrumentLookup': { reqName: 'instrumentListRequest',
+                          resName: 'InstrumentListResponse' },
+    'CurveLookup':      { reqName: 'curveListRequest',
+                          resName: 'CurveListResponse' },
+    'GovernmentLookup': { reqName: 'govtListRequest',
+                          resName: 'GovtListResponse' }
+};
+
 // ANONYMOUS FUNCTIONS
 function isObjectEmpty(obj: Object): boolean {
     return (0 === Object.getOwnPropertyNames(obj).length);
-}
-
-function reqName2RespName(name: string): string {
-    return name.replace(/^Field\w+/, 'field') + 'Response';
 }
 
 function subscriptionsToServices(subscriptions: Subscription[]): string[] {
@@ -284,8 +294,8 @@ export class Session extends events.EventEmitter {
         this.requests[correlatorId] = callback;
 
         this.openService(uri).then((): void => {
-            var responseEventName = reqName2RespName(name);
-            var requestName = name + 'Request';
+            var responseEventName = NAME_MAP[name].resName;
+            var requestName = NAME_MAP[name].reqName;
             log(util.format('Request: %s|%d', requestName, correlatorId));
             trace(request);
             this.session.request(uri, requestName, request, correlatorId);


### PR DESCRIPTION
I don't have working examples for Curve and Government lookup requests yet but I should be able to come up with some. 
There isn't an example for FieldSearch either. I added the service to the map because Yu Ping mentioned it.
We should probably try to have at least one example for each service that is supported.
