### PR TITLE
Fix examples to include 'Request'.

### DIFF
--- a/doc/http-api-guide.md
+++ b/doc/http-api-guide.md
@@ -178,7 +178,7 @@ request must specify at least one security and at least one field.
 Example request/response:
 
 ```
-curl -X POST 'http://blpapihost.example.com/request?ns=blp&service=refdata&type=ReferenceData' --data @- <<EOF
+curl -X POST 'http://blpapihost.example.com/request?ns=blp&service=refdata&type=ReferenceDataRequest' --data @- <<EOF
 { "securities": ["IBM US Equity", "AAPL US Equity"],
   "fields": ["PX_LAST", "NAME", "EPS_ANNUALIZED"] }
 EOF
@@ -231,7 +231,7 @@ specify `"returnFieldDocumentation": "true"`.
 Example request/response:
 
 ```
-curl -X POST 'http://blpapihost.example.com/request&ns=blp&service=apiflds&type=FieldInfo' --data @- <<EOF
+curl -X POST 'http://blpapihost.example.com/request&ns=blp&service=apiflds&type=FieldInfoRequest' --data @- <<EOF
 { "id": ["NAME"],
   "returnFieldDocumentation": "true" }
 EOF

--- a/examples/java/ReferenceData.java
+++ b/examples/java/ReferenceData.java
@@ -16,7 +16,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class ReferenceData {
     public static final String apiUrl = "https://http-api.openbloomberg.com"
-        + "/request?ns=blp&service=refdata&type=ReferenceData";
+        + "/request?ns=blp&service=refdata&type=ReferenceDataRequest";
     public static final String keyStorePW = "secure";
     public static final String trustStorePW = "secure2";
     public static final String clientCert = "client.p12";

--- a/examples/node/HistoricalDataRequest.js
+++ b/examples/node/HistoricalDataRequest.js
@@ -8,7 +8,7 @@ var port = 443
 var options = {
     host: host,
     port: port,
-    path: '/request?ns=blp&service=refdata&type=HistoricalData',
+    path: '/request?ns=blp&service=refdata&type=HistoricalDataRequest',
     method: 'POST',
     key: fs.readFileSync('client.key'),
     cert: fs.readFileSync('client.crt'),

--- a/examples/python/HistoricalDataRequest.py
+++ b/examples/python/HistoricalDataRequest.py
@@ -17,14 +17,14 @@ data = {
 }
 
 def request(args):
-    req = urllib2.Request('https://{}/request?ns=blp&service=refdata&type=HistoricalData'.format(args.host))
+    req = urllib2.Request('https://{}/request?ns=blp&service=refdata&type=HistoricalDataRequest'.format(args.host))
     req.add_header('Content-Type', 'application/json')
 
     ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     ctx.load_verify_locations('bloomberg.crt')
     ctx.load_cert_chain('client.crt', 'client.key')
 
-    try: 
+    try:
         res = urllib2.urlopen(req, data=json.dumps(data), context=ctx)
         print res.read()
     except Exception as e:

--- a/examples/python/python3/HistoricalDataRequest.py
+++ b/examples/python/python3/HistoricalDataRequest.py
@@ -17,7 +17,7 @@ data = {
 }
 
 def request(args):
-    req = urllib.request.Request('https://{}/request?ns=blp&service=refdata&type=HistoricalData'.format(args.host))
+    req = urllib.request.Request('https://{}/request?ns=blp&service=refdata&type=HistoricalDataRequest'.format(args.host))
     req.add_header('Content-Type', 'application/json')
 
     ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
@@ -28,7 +28,7 @@ def request(args):
     opener = urllib.request.build_opener(https_sslv23_handler)
     urllib.request.install_opener(opener)
 
-    try: 
+    try:
         res = opener.open(req, data=json.dumps(data).encode("ascii"))
         print(res.read())
     except Exception as e:

--- a/examples/shell/FieldInfo.sh
+++ b/examples/shell/FieldInfo.sh
@@ -9,7 +9,7 @@ fi
 
 REQUEST="$1"
 
-curl -v -X POST "https://http-api.openbloomberg.com/request?ns=blp&service=apiflds&type=FieldInfo"  \
+curl -v -X POST "https://http-api.openbloomberg.com/request?ns=blp&service=apiflds&type=FieldInfoRequest"  \
     --cacert bloomberg.crt \
     --cert   client.crt    \
     --key    client.key    \

--- a/examples/shell/HistoricalDataRequest.sh
+++ b/examples/shell/HistoricalDataRequest.sh
@@ -9,7 +9,7 @@ fi
 
 REQUEST="$1"
 
-curl -v -X POST "https://http-api.openbloomberg.com/request?ns=blp&service=refdata&type=HistoricalData"  \
+curl -v -X POST "https://http-api.openbloomberg.com/request?ns=blp&service=refdata&type=HistoricalDataRequest"  \
     --cacert bloomberg.crt \
     --cert   client.crt    \
     --key    client.key    \

--- a/examples/shell/ReferenceData.sh
+++ b/examples/shell/ReferenceData.sh
@@ -8,7 +8,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 REQUEST="$1"
-curl -v -X POST "https://http-api.openbloomberg.com/request?ns=blp&service=refdata&type=ReferenceData"  \
+curl -v -X POST "https://http-api.openbloomberg.com/request?ns=blp&service=refdata&type=ReferenceDataRequest"  \
     --cacert bloomberg.crt \
     --cert   client.crt    \
     --key    client.key    \

--- a/test-example/testRequest.js
+++ b/test-example/testRequest.js
@@ -50,7 +50,7 @@ function clientRequest(clientId) {
         var delay = Math.floor((Math.random() * MAX_DELAY));
         var t = process.hrtime();
         request.postAsync({
-            url : HOST + '/request?ns=blp&service=refdata&type=HistoricalData',
+            url : HOST + '/request?ns=blp&service=refdata&type=HistoricalDataRequest',
             body :  {
                         securities: ['IBM US Equity', 'AAPL US Equity'],
                         fields: ['PX_LAST', 'OPEN', 'EPS_ANNUALIZED'],


### PR DESCRIPTION
When updating the URL scheme, I neglected to fix the requests
to reflect that we now require the full BLPAPI name.
