### PR TITLE
handling of 'error' event for subscriptions

### DIFF
--- a/lib/middleware/request-handler.ts
+++ b/lib/middleware/request-handler.ts
@@ -265,6 +265,17 @@ export function onSubscribe(req: Interface.IOurRequest,
                 // Buffer the current data
                 sub.buffer.pushValue(data);
             });
+
+            // Must subscribe to the 'error' event; otherwise EventEmitter will throw an exception
+            // that was occurring from the underlying blpapi.Session.  It is the assumed that the
+            // blpapi.Session properly cleans up the subscription (i.e., 'unsubscribe()' should not
+            // be called).
+            sub.on('error', (err: Error): void => {
+                req.log.error(err, 'blpapi.Session subscription error occurred.');
+                sub.removeAllListeners();
+                req.apiSession.activeSubscriptions.delete(sub.correlationId);
+                req.apiSession.receivedSubscriptions.delete(sub.correlationId);
+            });
         });
 
         // Subscribe user request through blpapi-wrapper


### PR DESCRIPTION
NodeJS's `EventEmitter` treats emitting 'error' as a special case - when
there are no listeners, an `Error` object is thrown on behalf of the
`EventEmitter`.  Due to this behavior, an unhandled exception was being
thrown from `blpapi-wrapper.ts` that wasn't allowing the
`SessionTerminated` event being propagated properly to the users of the
API.

This change now has subscriptions listen for the 'error' event to
properly update the internal state of outstanding subscriptions.

Closes #39
