### PR TITLE
extend ISocket abstraction to hide message structure details

### DIFF
--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -22,11 +22,20 @@ export interface IOurResponse extends restify.Response {
 }
 
 export interface ISocket extends NodeJS.EventEmitter {
+    // PROPERTIES
     log: bunyan.Logger; // Add bunyan logger to socket
     blpSession: BAPI.Session;  // Add blpSession to socket
+
+    // MANIPULATORS
+    sendData(correlationId: number, data: any): void;
+    sendError(message: string): void;
+    notifyConnected(): void;
+    notifySubscribed(): void;
+    notifyUnsubscribed(all: boolean): void;
+    disconnect(): void;
+
+    // ACCESSORS
     isConnected(): boolean;
     getIP(): string;
     getCert(): any;
-    disconnect(): void;
-    send(name: string, ...args: any[]): void;
 }

--- a/lib/websocket/socket-base-impl.ts
+++ b/lib/websocket/socket-base-impl.ts
@@ -1,0 +1,88 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+import events = require('events');
+import bunyan = require('bunyan');
+import blpapi = require('../blpapi-wrapper');
+import Interface = require('../interface');
+import emitterAdapter = require('./socket-event-emitter-adapter');
+
+export = SocketBaseImpl;
+
+class SocketBaseImpl extends emitterAdapter.SocketEventEmitterAdapter implements Interface.ISocket {
+
+    // DATA
+    private _logger: bunyan.Logger;
+    private _blpapiSession: blpapi.Session;
+
+    // PROTECTED MANIPULATORS
+    protected send(name: string, ...args: any[]): void {
+        throw new Error('send() must be implemented');
+    }
+
+    // CREATORS
+    constructor(logger: bunyan.Logger,
+                emitterToAdapt: emitterAdapter.EventEmitter = new events.EventEmitter())
+    {
+        super(emitterToAdapt);
+        this._logger = logger;
+    }
+
+    // MANIPULATORS
+    sendData(correlationId: number, data: any): void {
+        this.send('data', {
+            correlationId: correlationId,
+            data: data
+        });
+    }
+
+    sendError(message: string): void {
+        this.send('err', { message: message });
+    }
+
+    notifyConnected(): void {
+        this.send('connected');
+    }
+
+    notifySubscribed(): void {
+        this.send('subscribed');
+    }
+
+    notifyUnsubscribed(all: boolean = false): void {
+        var message = 'unsubscribe';
+        if (all) {
+            message += ' all';
+        }
+        this.send(message);
+    }
+
+    disconnect(): void {
+        throw new Error('disconnect() must be implemented');
+    }
+
+    // PROPERTIES
+    /* tslint:disable:typedef */
+    set blpSession(session: blpapi.Session) {
+        this._blpapiSession = session;
+    }
+    /* tslint:enable:typedef */
+    get blpSession(): blpapi.Session {
+        return this._blpapiSession;
+    }
+
+    // ACCESSORS
+    get log(): bunyan.Logger {
+        return this._logger;
+    }
+
+    isConnected(): boolean {
+        throw new Error('isConnected() must be implemented');
+    }
+
+    getIP(): string {
+        throw new Error('getIP() must be implemented');
+    }
+
+    getCert(): any {
+        throw new Error('getCert() must be implemented');
+    }
+}

--- a/lib/websocket/socket-event-emitter-adapter.ts
+++ b/lib/websocket/socket-event-emitter-adapter.ts
@@ -6,15 +6,15 @@ import events = require('events');
 // TYPEDEF
 var EVENTEMITTERPROTOTYPE = events.EventEmitter.prototype;
 
-export = SocketEventEmitterAdapter;
+export type EventEmitter = SocketIO.Socket | NodeJS.EventEmitter;
 
-class SocketEventEmitterAdapter implements events.EventEmitter {
+export class SocketEventEmitterAdapter implements events.EventEmitter {
     // DATA
-    private emitter: SocketIO.Socket;
+    private emitter: EventEmitter;
 
     // CREATORS
-    constructor(socket: SocketIO.Socket) {
-        this.emitter = socket;
+    constructor(emitter: EventEmitter) {
+        this.emitter = emitter;
     }
 
     // NodeJS.EventEmitter implement
@@ -52,9 +52,13 @@ class SocketEventEmitterAdapter implements events.EventEmitter {
     }
 
     emit(event: string, ...args: any[]): boolean {
-        // Note that we want to stub calls to 'emit' because SocketIO.Socket.emit is specialized
-        // and does not follow the the standard NodeJS.EventEmitter interface.
-        assert(false, '“emit” should not be called on SocketEventEmitterAdapter');
-        return false;
+        if (this.emitter instanceof events.EventEmitter) {
+            return EVENTEMITTERPROTOTYPE.emit.apply(this.emitter, arguments);
+        } else {
+            // Note that we want to stub calls to 'emit' because SocketIO.Socket.emit is specialized
+            // and does not follow the the standard NodeJS.EventEmitter interface.
+            assert(false, '“emit” should not be called on SocketEventEmitterAdapter');
+            return false;
+        }
     }
 }

--- a/lib/websocket/socket-io-wrapper.ts
+++ b/lib/websocket/socket-io-wrapper.ts
@@ -2,27 +2,31 @@
 
 import bunyan = require('bunyan');
 import SocketIO = require('socket.io');
-import BAPI = require('../blpapi-wrapper');
-import Interface = require('../interface');
-import SocketEventEmitterAdapter = require('./socket-event-emitter-adapter');
+import SocketBaseImpl = require('./socket-base-impl');
 
 export = SocketIOWrapper;
 
-class SocketIOWrapper extends SocketEventEmitterAdapter implements Interface.ISocket {
+class SocketIOWrapper extends SocketBaseImpl {
+    // DATA
     private socket: SocketIO.Socket;
-    private _log: bunyan.Logger;
-    public blpSession: BAPI.Session;
 
+    // PROTECTED MANIPULATORS
+    protected send(name: string, ...args: any[]): void {
+        this.socket.emit(name, args);
+    }
+
+    // CREATORS
     constructor(s: SocketIO.Socket, l: bunyan.Logger) {
-        super(s);
+        super(l, s);
         this.socket = s;
-        this._log = l;
     }
 
-    get log(): bunyan.Logger {
-        return this._log;
+    // MANIPULATORS
+    disconnect(): void {
+        this.socket.disconnect(true);
     }
 
+    // ACCESSORS
     isConnected(): boolean {
         return this.socket.connected;
     }
@@ -35,13 +39,4 @@ class SocketIOWrapper extends SocketEventEmitterAdapter implements Interface.ISo
     getCert(): any {
         return this.socket.request.connection.getPeerCertificate();
     }
-
-    disconnect(): void {
-        this.socket.disconnect(true);
-    }
-
-    send(name: string, ...args: any[]): void {
-        this.socket.emit(name, args);
-    }
-
 }


### PR DESCRIPTION
This change extends `interface ISocket` so that the message structure is
handled by a base class implementation.  `SocketBaseImpl` was introduced
to be a partial abstract-base-class that handles most of the `ISocket`
interface, while stubbing out with exceptions the methods that must be
implemented by the parent class.  The `Socket.IO` and `ws`
implementations are modified to subclass `SocketBaseImpl` and the APIs
called in `websocket-handler.ts` are updated appropriately.
