### PR TITLE
Replace req.params with req.query in subscription

### DIFF
--- a/lib/middleware/api-session.ts
+++ b/lib/middleware/api-session.ts
@@ -27,7 +27,7 @@ export function handleSession(req: Interface.IOurRequest,
 
     if (!apiSession) {
         // If this is a new subscription, create the session.
-        if (req.method === 'POST' && req.params.action === 'start') {
+        if (req.method === 'POST' && req.query.action === 'start') {
             apiSession = new Session(req.blpSession);
             SESSIONSTORE.set(req.clientCert.fingerprint, apiSession);
             req.log.debug('New apisession created.');

--- a/test-example/testLongPoll.js
+++ b/test-example/testLongPoll.js
@@ -48,7 +48,7 @@ function clientRequest(clientId) {
 
     // Subscribe
     request.postAsync({
-        url : HOST + '/subscribe',
+        url : HOST + '/subscription?action=start',
         body : [
                 { security: 'AAPL US Equity', correlationId: 0, fields: ['LAST_PRICE'] },
                 { security: 'GOOG US Equity', correlationId: 1, fields: ['LAST_PRICE'] }
@@ -75,7 +75,7 @@ function clientRequest(clientId) {
         var delay = Math.floor((Math.random() * MAX_DELAY));
         var t = process.hrtime();
         request.getAsync({
-            url : HOST + '/poll?pollid=' + counter,
+            url : HOST + '/subscription?pollid=' + counter,
             pool: agent,
             json: true,
             agentOptions: opt
@@ -97,7 +97,7 @@ function clientRequest(clientId) {
             }
             else {
                 request.postAsync({
-                    url : HOST + '/unsubscribe',
+                    url : HOST + '/subscription?action=stop',
                     //body : { correlationIds: [0] },
                     pool: agent,
                     json: true,

--- a/test-example/testLongPoll2.js
+++ b/test-example/testLongPoll2.js
@@ -48,7 +48,7 @@ function clientRequest(clientId) {
 
     // Subscribe
     request.postAsync({
-        url : HOST + '/subscribe',
+        url : HOST + '/subscription?action=start',
         body : [
                 { security: 'AAPL US Equity', correlationId: 0, fields: ['LAST_PRICE'] },
                 { security: 'GOOG US Equity', correlationId: 1, fields: ['LAST_PRICE'] }
@@ -75,7 +75,7 @@ function clientRequest(clientId) {
                 var delay = Math.floor((Math.random() * MAX_DELAY));
                 var t = process.hrtime();
                 request.getAsync({
-                    url : HOST + '/poll?pollid=' + result.poll,
+                    url : HOST + '/subscription?pollid=' + result.poll,
                     pool: agent,
                     agentOptions: opt
                 })
@@ -99,7 +99,7 @@ function clientRequest(clientId) {
             }
             else {
                 request.postAsync({
-                    url : HOST + '/unsubscribe',
+                    url : HOST + '/subscription?action=stop',
                     body : JSON.stringify({ correlationIds: [0] }),
                     pool: agent,
                     agentOptions: opt
@@ -109,7 +109,7 @@ function clientRequest(clientId) {
                 })
                 .then(function() {
                     return request.getAsync({
-                        url : HOST + '/poll?pollid=1',
+                        url : HOST + '/subscription?pollid=1',
                         pool: agent,
                         agentOptions: opt
                     });


### PR DESCRIPTION
Found one problem with the subscription code where we use `req.params` instead of `req.query`. Also update `long-polling` example to match the latest URL scheme.
