### PR TITLE
Basic authorization support.

### DIFF
--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -1,5 +1,6 @@
 /// <reference path='../typings/tsd.d.ts' />
 
+import blpapi = require('blpapi');
 import restify = require('restify');
 import bunyan = require('bunyan');
 import BAPI = require('./blpapi-wrapper');
@@ -9,6 +10,7 @@ export interface IOurRequest extends restify.Request {
     clientCert?: any;
     blpSession: BAPI.Session;
     apiSession?: Session;
+    identity?: blpapi.Identity;
 }
 
 export interface IBufferedData<T> {

--- a/lib/middleware/auth.ts
+++ b/lib/middleware/auth.ts
@@ -1,0 +1,33 @@
+/// <reference path='../../typings/tsd.d.ts' />
+
+// Handles client auth operations.
+// Currently we only have authorization (e.g. Identity management), associating the identities with
+// client certs.
+
+import blpapi = require('blpapi');
+import _ = require('lodash');
+import restify = require('restify');
+import Interface = require('../interface');
+import Map = require('../util/map');
+
+var sIdentityMap: Map<blpapi.Identity> = new Map<blpapi.Identity>();
+
+export function getIdentity(req: Interface.IOurRequest,
+                            res: Interface.IOurResponse,
+                            next: restify.Next): void
+{
+    if (_.has(req, 'clientCert')) {
+        req.identity = sIdentityMap.get(req.clientCert.fingerprint) || null;
+    } else {
+        req.identity = null;
+    }
+    return next();
+}
+
+export function setIdentity(req: Interface.IOurRequest, identity: blpapi.Identity): void
+{
+    if (!_.has(req, 'clientCert')) {
+        throw new Error('Cannot setIdentity without a client cert');
+    }
+    sIdentityMap.set(req.clientCert.fingerprint, identity);
+}

--- a/lib/middleware/request-validator.ts
+++ b/lib/middleware/request-validator.ts
@@ -55,3 +55,8 @@ export function requireChoiceQueryParam(param: string, values: string[]): restif
         req.checkQuery(param, 'Invalid ' + param).isIn(values);
     });
 }
+
+export function requireActionQueryParam(values: string[]): restify.RequestHandler
+{
+    return requireChoiceQueryParam('action', values);
+}

--- a/lib/websocket/websocket-handler.ts
+++ b/lib/websocket/websocket-handler.ts
@@ -145,7 +145,8 @@ function setup(socket: Interface.ISocket): void
         });
 
         // Subscribe user request through blpapi-wrapper
-        socket.blpSession.subscribe(subscriptions)
+        // TODO: Support authorized identity.
+        socket.blpSession.subscribe(subscriptions, null)
             .then((): void => {
                 if (socket.isConnected()) {
                     subscriptions.forEach((s: Subscription): void => {

--- a/typings/blpapi/blpapi.d.ts
+++ b/typings/blpapi/blpapi.d.ts
@@ -19,19 +19,30 @@ declare module "blpapi" {
         correlation: number;
     }
 
+    // Opaque object representing an authorized Identity.
+    export interface Identity {
+
+    }
+
     import EventEmitter = NodeJS.EventEmitter;
 
     export class Session implements EventEmitter {
         constructor (args: SessionOpts);
         start(): Session;
         authorize(uri: string, cid: number): number;
+        authorizeUser(request: any, cid: number): number;
         stop(): Session;
         destroy(): Session;
         openService(uri: string, cid: number): number;
-        subscribe(subs: Subscription[], label?: string): Session;
+        subscribe(subs: Subscription[], identity?: Identity, label?: string): Session;
         resubscribe(subs: Subscription[], label?: string): Session;
         unsubscribe(subs: Subscription[]): Session;
-        request(uri: string, name: string, request: any, cid: number, label?: string): number;
+        request(uri: string,
+                name: string,
+                request: any,
+                cid: number,
+                identity?: Identity,
+                label?: string): number;
 
         addListener(event: string, listener: Function): EventEmitter;
         on(event: string, listener: Function): EventEmitter;


### PR DESCRIPTION
This allows users to supply an authorization token and
tracks the created identities across requests (based on
client cert). Closes #15 in a narrow sense although the
feature is not very usable until #102 is also fixed.

Also includes a refactor of dispatching requests with action
query parameters.
