### PR TITLE
Add sendError to response object

### DIFF
--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -19,6 +19,7 @@ export interface IBufferedData<T> {
 export interface IOurResponse extends restify.Response {
     sendChunk?: (data: any) => void;
     sendEnd?: (status: any, message: string) => void;
+    sendError?: (err: Error) => any;
 }
 
 export interface ISocket extends NodeJS.EventEmitter {


### PR DESCRIPTION
This PR adds a `sendError` function which sent error message over the wire. We use this function to indicate error for cases we can't predetermined and need to go through the `blpapi`. This PR address #98.
