### PR TITLE
Remove argument array in websocket

### DIFF
--- a/lib/websocket/socket-base-impl.ts
+++ b/lib/websocket/socket-base-impl.ts
@@ -15,7 +15,7 @@ class SocketBaseImpl extends emitterAdapter.SocketEventEmitterAdapter implements
     private _blpapiSession: blpapi.Session;
 
     // PROTECTED MANIPULATORS
-    protected send(name: string, ...args: any[]): void {
+    protected send(name: string, arg?: any): void {
         throw new Error('send() must be implemented');
     }
 

--- a/lib/websocket/socket-io-wrapper.ts
+++ b/lib/websocket/socket-io-wrapper.ts
@@ -11,8 +11,8 @@ class SocketIOWrapper extends SocketBaseImpl {
     private socket: SocketIO.Socket;
 
     // PROTECTED MANIPULATORS
-    protected send(name: string, ...args: any[]): void {
-        this.socket.emit(name, args);
+    protected send(name: string, arg?: any): void {
+        this.socket.emit(name, arg);
     }
 
     // CREATORS

--- a/lib/websocket/ws-wrapper.ts
+++ b/lib/websocket/ws-wrapper.ts
@@ -12,8 +12,8 @@ class WSWrapper extends SocketBaseImpl {
     private socket: webSocket;
 
     // PROTECTED MANIPULATORS
-    protected send(name: string, ...args: any[]): void {
-        this.socket.send(JSON.stringify({type: name, data: args}));
+    protected send(name: string, arg?: any): void {
+        this.socket.send(JSON.stringify({type: name, data: arg}));
     }
 
     // CREATORS


### PR DESCRIPTION
Noticed a small issue while testing `websocket` that the object being sent over the wire is wrapped in a redundant array. 
This is due to the generated js for `...args` syntax.
Since we are not using anywhere else for multiple arguments, remove the unnecessary argument array.
