### PR TITLE
Updated 'align' rule to handle arguments in constructor calls.

### DIFF
--- a/tslint-rules/alignRule.ts
+++ b/tslint-rules/alignRule.ts
@@ -48,6 +48,11 @@ class AlignWalker extends Lint.RuleWalker {
         super.visitCallExpression(node);
     }
 
+    public visitNewExpression(node: ts.NewExpression) {
+        this.checkAlignment(Rule.ARGUMENTS_OPTION, node.arguments);
+        super.visitNewExpression(node);
+    }
+
     public visitBlock(node: ts.Block) {
         this.checkAlignment(Rule.STATEMENTS_OPTION, node.statements);
         super.visitBlock(node);


### PR DESCRIPTION
I didn't notice initially that that constructor invocation is folded into a 'new expression'.
