### PR TITLE
bind this in _.map

### DIFF
--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -446,7 +446,7 @@ export class Session extends events.EventEmitter {
                 return result;
             }
 
-            var subs = _.map(subscriptionsAndServices, makeSubscription);
+            var subs = _.map(subscriptionsAndServices, makeSubscription, this);
             this.session.subscribe(subs, identity);
         }).nodeify(cb);
     }


### PR DESCRIPTION
Fix problem in the `blpapi-wrapper.ts` where we didn't bind `this` arg specifically so `this.nextCorrelatorId()` will fail.
