### PR TITLE
Send correlation ids with subscribed and unsubscribed events.

### DIFF
--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -20,7 +20,12 @@ export interface IBufferedData<T> {
 
 export interface IOurResponse extends restify.Response {
     sendChunk?: (data: any) => void;
-    sendEnd?: (status: any, message: string) => void;
+    sendOtherProp?: (properties: { [index: string]: any; }) => void;
+    sendEnd?: (status: number, message: string) => void;
+    sendWhole?: (status: number,
+                 message: string,
+                 properties?: { [index: string]: any; },
+                 data?: any) => void;
     sendError?: (err: Error) => any;
 }
 
@@ -33,8 +38,8 @@ export interface ISocket extends NodeJS.EventEmitter {
     sendData(correlationId: number, data: any): void;
     sendError(message: string): void;
     notifyConnected(): void;
-    notifySubscribed(): void;
-    notifyUnsubscribed(all: boolean): void;
+    notifySubscribed(correlationIds: number[]): void;
+    notifyUnsubscribed(correlationIds: number[]): void;
     disconnect(): void;
 
     // ACCESSORS

--- a/lib/websocket/socket-base-impl.ts
+++ b/lib/websocket/socket-base-impl.ts
@@ -43,16 +43,12 @@ class SocketBaseImpl extends emitterAdapter.SocketEventEmitterAdapter implements
         this.send('connected');
     }
 
-    notifySubscribed(): void {
-        this.send('subscribed');
+    notifySubscribed(correlationIds: number[]): void {
+        this.send('subscribed', correlationIds);
     }
 
-    notifyUnsubscribed(all: boolean = false): void {
-        var message = 'unsubscribed';
-        if (all) {
-            message += ' all';
-        }
-        this.send(message);
+    notifyUnsubscribed(correlationIds: number[]): void {
+        this.send('unsubscribed', correlationIds);
     }
 
     disconnect(): void {

--- a/lib/websocket/websocket-handler.ts
+++ b/lib/websocket/websocket-handler.ts
@@ -31,6 +31,12 @@ export function wsOnConnect(s: webSocket): void
 }
 
 // PRIVATE FUNCTIONS
+function getCorrelationIds(subscriptions: Subscription[]): number[] {
+    return subscriptions.map((s: Subscription): number => {
+        return s.correlationId;
+    });
+}
+
 function onConnect(socket: Interface.ISocket): void
 {
     initialize(socket)
@@ -159,7 +165,7 @@ function setup(socket: Interface.ISocket): void
                         activeSubscriptions.set(s.correlationId, s);
                     });
                     socket.log.debug('Subscribed');
-                    socket.notifySubscribed();
+                    socket.notifySubscribed(getCorrelationIds(subscriptions));
                 } else { // Unsubscribe if socket already closed
                     try {
                         socket.blpSession.unsubscribe(subscriptions);
@@ -247,7 +253,7 @@ function setup(socket: Interface.ISocket): void
             activeSubscriptions.delete(s.correlationId);
             receivedSubscriptions.delete(s.correlationId);
         });
-        socket.notifyUnsubscribed(0 === receivedSubscriptions.size);
+        socket.notifyUnsubscribed(getCorrelationIds(subscriptions));
         socket.log.debug({activeSubscriptions: activeSubscriptions.size}, 'Unsubscribed.');
     });
 

--- a/test/subscription-socket-io.test.ts
+++ b/test/subscription-socket-io.test.ts
@@ -358,6 +358,20 @@ describe('Subscription-socket-io', (): void => {
                         });
                     });
                 });
+
+                it('should receive correlation ids with subscribed event',
+                   (done: Function): void => {
+                    var subscriptions = [
+                        { security: '//blp/mktdata', correlationId: 0, fields: ['P'] },
+                        { security: '//blp/mktdata', correlationId: 1, fields: ['P'] },
+                        { security: '//blp/mktdata', correlationId: 2, fields: ['P'] }
+                    ];
+                    socket.emit('subscribe', subscriptions);
+                    socket.on('subscribed', (correlationIds: number[]): void => {
+                        correlationIds.sort().should.be.an.Array.and.eql([0, 1, 2]);
+                        done();
+                    });
+                });
             });
 
             describe('#unsubscribe', (): void => {
@@ -369,17 +383,17 @@ describe('Subscription-socket-io', (): void => {
                         done();
                     });
                 });
-                it('should unsubscribe all if body is umpty', (done: Function): void => {
-                    socket.emit('subscribe',
-                                [
-                                    { security: '//blp/mktdata', correlationId: 0, fields: ['P'] },
-                                    { security: '//blp/mktdata', correlationId: 1, fields: ['P'] }
-                                ]
-                    );
+                it('should unsubscribe all if body is empty', (done: Function): void => {
+                    var subscriptions = [
+                        { security: '//blp/mktdata', correlationId: 0, fields: ['P'] },
+                        { security: '//blp/mktdata', correlationId: 1, fields: ['P'] }
+                    ];
+                    socket.emit('subscribe', subscriptions);
                     socket.on('subscribed', (): void => {
                         socket.emit('unsubscribe');
                     });
-                    socket.on('unsubscribed all', (): void => {
+                    socket.on('unsubscribed', (correlationIds: number[]): void => {
+                        correlationIds.sort().should.be.an.Array.and.eql([0, 1]);
                         done();
                     });
                 });
@@ -424,16 +438,16 @@ describe('Subscription-socket-io', (): void => {
                     });
                 });
                 it('should unsubscribe all if all correlationIds', (done: Function): void => {
-                    socket.emit('subscribe',
-                                [
-                                    { security: '//blp/mktdata', correlationId: 0, fields: ['P'] },
-                                    { security: '//blp/mktdata', correlationId: 1, fields: ['P'] }
-                                ]
-                    );
+                    var subscriptions = [
+                        { security: '//blp/mktdata', correlationId: 0, fields: ['P'] },
+                        { security: '//blp/mktdata', correlationId: 1, fields: ['P'] }
+                    ];
+                    socket.emit('subscribe', subscriptions);
                     socket.on('subscribed', (): void => {
                         socket.emit('unsubscribe', { correlationIds: [0, 1] });
                     });
-                    socket.on('unsubscribed all', (): void => {
+                    socket.on('unsubscribed', (correlationIds: number[]): void => {
+                        correlationIds.should.be.an.Array.and.eql([0, 1]);
                         done();
                     });
                 });
@@ -484,10 +498,28 @@ describe('Subscription-socket-io', (): void => {
                             socket.emit('unsubscribe');
                         }
                     });
-                    socket.on('unsubscribed all', (): void => {
+                    socket.on('unsubscribed', (correlationIds: number[]): void => {
+                        correlationIds.should.be.an.Array.and.eql([0]);
                         socket.disconnect();
                     });
                     socket.on('disconnect', (): void => {
+                        done();
+                    });
+                });
+
+                it('should receive correlation ids with unsubscribed event',
+                   (done: Function): void => {
+                    var subscriptions = [
+                        { security: '//blp/mktdata', correlationId: 0, fields: ['P'] },
+                        { security: '//blp/mktdata', correlationId: 1, fields: ['P'] },
+                        { security: '//blp/mktdata', correlationId: 2, fields: ['P'] }
+                    ];
+                    socket.emit('subscribe', subscriptions);
+                    socket.on('subscribed', (): void => {
+                        socket.emit('unsubscribe');
+                    });
+                    socket.on('unsubscribed', (correlationIds: number[]): void => {
+                        correlationIds.sort().should.be.an.Array.and.eql([0, 1, 2]);
                         done();
                     });
                 });


### PR DESCRIPTION
Also modified examples and changed the unsubscribe event name to 'unsubscribed'.
Issue #124.
