### PR TITLE
Quick fix for requests without identities.

### DIFF
--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -277,6 +277,8 @@ export class Session extends events.EventEmitter {
             if (isAuthRequest) {
                 this.session.authorizeUser(request, correlatorId);
             } else {
+                // TODO: blpapi-node doesn't accept null; remove this when that's fixed.
+                identity = identity || undefined;
                 this.session.request(uri, requestName, request, correlatorId, identity);
             }
             assert(requestName in REQUEST_TO_RESPONSE_MAP,
@@ -447,6 +449,8 @@ export class Session extends events.EventEmitter {
             }
 
             var subs = _.map(subscriptionsAndServices, makeSubscription, this);
+            // TODO: blpapi-node doesn't accept null; remove this when that's fixed.
+            identity = identity || undefined;
             this.session.subscribe(subs, identity);
         }).nodeify(cb);
     }

--- a/lib/websocket/websocket-handler.ts
+++ b/lib/websocket/websocket-handler.ts
@@ -146,7 +146,7 @@ function setup(socket: Interface.ISocket): void
 
         // Subscribe user request through blpapi-wrapper
         // TODO: Support authorized identity.
-        socket.blpSession.subscribe(subscriptions, null)
+        socket.blpSession.subscribe(subscriptions, undefined)
             .then((): void => {
                 if (socket.isConnected()) {
                     subscriptions.forEach((s: Subscription): void => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bloomberg Open API HTTP Proxy",
   "main": "server.js",
   "dependencies": {
-    "blpapi": "^1.0.0",
+    "blpapi": "^1.1.0",
     "bluebird": "^2.8.2",
     "bunyan": "^1.2.3",
     "convict": "^0.6.1",


### PR DESCRIPTION
When I switched from undefined -> null I didn't realize
this wouldn't work because blpapi-node expects an object or
undefined.
