### PR TITLE
Change of run path at end of README

### DIFF
--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -33,5 +33,5 @@ TrustManager. Password protected: `secure2`.
 ## Run
 
 ```
-$ java ReferenceData ../json/ReferenceData/IBMHolders.json 
+$ java ReferenceData ../json/ReferenceData/IBMHolders.json
 ```

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -33,5 +33,5 @@ TrustManager. Password protected: `secure2`.
 ## Run
 
 ```
-$ java ReferenceData ../examples/ReferenceData/IBMHolders.json
+$ java ReferenceData ../json/ReferenceData/IBMHolders.json 
 ```


### PR DESCRIPTION
At the end of the instructions, the run path needs to be changed accordingly or user will get a FileNotFoundException. There is no ../examples directory.
