### PR TITLE
setup listeners for subscribed/unsubscribed events on 'on connect'.

### DIFF
--- a/examples/node/MarketDataSubscription_socketio.js
+++ b/examples/node/MarketDataSubscription_socketio.js
@@ -27,10 +27,9 @@ var opt = {
 
 var socket = io.connect(url, opt);
 
-socket.on('connected', function () {
-    // XXX: This listner should be removed once #123 is closed.
+socket.on('connect', function () {
     console.log('Connected');
-    socket.emit('subscribe', subscriptions);
+    socket.emit('subscribe', SUBSCRIPTIONS);
 });
 
 var data_events_count = 0;

--- a/examples/node/MarketDataSubscription_ws.js
+++ b/examples/node/MarketDataSubscription_ws.js
@@ -21,11 +21,6 @@ var unsubscribe_count = 0;
 function dispatch(socket, msg) {
     var msg = JSON.parse(msg);
     switch (msg.type) {
-      case 'connected': {
-        // XXX: This case should be removed once #123 is closed.
-        console.log('Connected');
-        socket.send(serialize('subscribe', SUBSCRIPTIONS));
-      } break;
       case 'data': {
         console.log(msg.data);
         if (++data_events_count == N_DATA_EVENTS) {
@@ -67,6 +62,10 @@ var opt = {
 };
 
 var socket = new WebSocket(url, opt);
+socket.on('open', function() {
+    console.log('Connection opened');
+    socket.send(serialize('subscribe', SUBSCRIPTIONS));
+});
 socket.on('message', dispatch.bind(null, socket));
 socket.on('close', function() {
     console.log('Socket disconected');

--- a/test/subscription-socket-io.test.ts
+++ b/test/subscription-socket-io.test.ts
@@ -83,7 +83,7 @@ describe('Subscription-socket-io', (): void => {
         });
 
         it('should let client connect successfully', (done: Function): void => {
-            socket.once('connected', (): void => {
+            socket.once('connect', (): void => {
                 done();
             });
         });
@@ -552,7 +552,7 @@ describe('Subscription-socket-io', (): void => {
                     });
                     socket.on('disconnect', (): void => {
                         socket = io.connect(url, opt);
-                        socket.on('connected', (): void => {
+                        socket.on('connect', (): void => {
                             done();
                         });
                     });


### PR DESCRIPTION
This addresses #123.
I made the registration of listeners synchronous with the 'on connect' event handling. Also, whatever is dependent on the BLPAPI session within these listeners will wait for completion of the session creation.
Additionally, I refactored a bit some duplicated logic for unsubscription and subscription cleanup.
