### PR TITLE
Add support for AuthenticationMode=APPLICATION_ONLY

### DIFF
--- a/lib/middleware/blp-session.ts
+++ b/lib/middleware/blp-session.ts
@@ -19,9 +19,10 @@ var LOGGER: bunyan.Logger = bunyan.createLogger(conf.get('loggerOptions'));
 function createSession(sessionId: string): Promise<blpapi.Session>
 {
     if (!(sessionId in SESSION_STORE)) {
-        var s = new blpapi.Session(DEFAULT_SESSION_OPTIONS);
+        var sessionOptions = DEFAULT_SESSION_OPTIONS;
+        var s = new blpapi.Session(sessionOptions.blpapiSessionOptions);
         var p = s.start()
-            .then((): blpapi.Session => {
+            .then((): void => {
                 LOGGER.info('blpSession created and connected.');
                 s.once('SessionTerminated', (): void => {
                     LOGGER.info('blpSession termintated.');
@@ -32,15 +33,22 @@ function createSession(sessionId: string): Promise<blpapi.Session>
                     LOGGER.info('Server Config ' + config + ' changes. Stop blpSession.');
                     s.stop();
                 });
-                return s;
-            })
-            .catch((err: Error): any => {  // Use any to make ts happy
-                delete SESSION_STORE[sessionId];
-                LOGGER.error(err, 'blpSession connection error.');
-                throw err;
             });
+        // We don't chain this promise to avoid the empty tick when authorizeOnStartup is false.
+        if (sessionOptions.authorizeOnStartup) {
+            p = p.then((): Promise<void> => {
+                return s.authorize();
+            });
+        }
+        // p.return is changing the type of the promise, so we can't store it in the same variable.
+        var p2 = p.return(s);
+        p2.catch((err: Error): any => {  // Use any to make ts happy
+            delete SESSION_STORE[sessionId];
+            LOGGER.error(err, 'blpSession connection error.');
+            throw err;
+        });
 
-        SESSION_STORE[sessionId] = p;
+        SESSION_STORE[sessionId] = p2;
     }
 
     return SESSION_STORE[sessionId];


### PR DESCRIPTION
This change adds a config option for api.authenticationAppName.
When this is set, sessions are created with authentication options
set to APPLICATION_ONLY mode with the specified app name, and
the default Identity for the session is authorized appropriately.
Other authentication modes are not yet supported.

This change also has a small refactor of doRequest to support
the third kind of request -- rather than passing isAuthRequest,
we now pass the actual function to perform the request.
