### PR TITLE
Remove dependency from interface.ts

### DIFF
--- a/lib/apisession/session.ts
+++ b/lib/apisession/session.ts
@@ -2,25 +2,27 @@
 
 import bunyan = require('bunyan');
 import BAPI = require('../blpapi-wrapper');
-import Subscription = require('../subscription/subscription');
 import Map = require('../util/map');
 import conf = require('../config');
+import interfaces = require('../interface');
 
 function curSeconds(): number
 {
     return process.hrtime()[0];
 }
 
+type ISubscription = interfaces.ISubscription;
+
 export = Session;
 
-class Session {
+class Session implements interfaces.IAPISession {
     // PRIVATE VARIABLES
     private _blpsess: BAPI.Session;
     private _logger: bunyan.Logger;
     private _seconds: number; // Last checked activity timestamp
     private _expired: boolean = false;
-    private _activeSubscriptions: Map<Subscription> = new Map<Subscription>();
-    private _receivedSubscriptions: Map<Subscription> = new Map<Subscription>();
+    private _activeSubscriptions: Map<ISubscription> = new Map<ISubscription>();
+    private _receivedSubscriptions: Map<ISubscription> = new Map<ISubscription>();
 
     // PUBLIC VARIABLES
     public inUse: number = 0;
@@ -29,7 +31,7 @@ class Session {
 
     // PRIVATE FUNCTIONS
     private clear(): void {
-        this._receivedSubscriptions.forEach((sub: Subscription): boolean => {
+        this._receivedSubscriptions.forEach((sub: ISubscription): boolean => {
             sub.removeAllListeners();
             return true;
         });
@@ -62,11 +64,11 @@ class Session {
         return this._expired;
     }
 
-    get activeSubscriptions(): Map<Subscription> {
+    get activeSubscriptions(): Map<ISubscription> {
         return this._activeSubscriptions;
     }
 
-    get receivedSubscriptions(): Map<Subscription> {
+    get receivedSubscriptions(): Map<ISubscription> {
         return this._receivedSubscriptions;
     }
 

--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -4,18 +4,55 @@ import blpapi = require('blpapi');
 import restify = require('restify');
 import bunyan = require('bunyan');
 import BAPI = require('./blpapi-wrapper');
-import Session = require('./apisession/session');
-
-export interface IOurRequest extends restify.Request {
-    clientCert?: any;
-    blpSession: BAPI.Session;
-    apiSession?: Session;
-    identity?: blpapi.Identity;
-}
 
 export interface IBufferedData<T> {
     buffer: T[];
     overflow: number;
+}
+
+export interface IHistoricalBufferManager<T> {
+    pushValue(data: T): void;
+    startNewBuffer(bufferLength?: number): IBufferedData<T>;
+    getBuffer(depth?: number): IBufferedData<T>;
+    isEmpty(depth?: number): boolean;
+}
+
+export interface ISubscription extends BAPI.Subscription {
+    correlationId: number;
+    buffer: IHistoricalBufferManager<Object>;
+}
+
+export interface IMap<T> {
+    size: number;
+    clear(): void;
+    set(key: string|number, val: T): void;
+    get(key: string|number): T;
+    has(key: string|number): boolean;
+    delete(key: string|number): void;
+    keys(): string[];
+    values(): T[];
+    entries(): any[][];
+    forEach(callbackFn: (val: T, key?: string, map?: IMap<T>) => boolean, thisArg?: any): void;
+}
+
+export interface IAPISession {
+    inUse: number;
+    lastPollId: number;
+    lastSuccessPollId: number;
+    seconds: number;
+    expired: boolean;
+    activeSubscriptions: IMap<ISubscription>;
+    receivedSubscriptions: IMap<ISubscription>;
+    expire(): boolean;
+    renew(): void;
+    isExpirable(): boolean;
+}
+
+export interface IOurRequest extends restify.Request {
+    clientCert?: any;
+    blpSession: BAPI.Session;
+    apiSession?: IAPISession;
+    identity?: blpapi.Identity;
 }
 
 export interface IOurResponse extends restify.Response {

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -7,7 +7,6 @@ import validator = require('express-validator');
 import sio = require('socket.io');
 import webSocket = require('ws');
 import conf = require('./config');
-import Interface = require('./interface');
 import auth = require('./middleware/auth');
 import blpSession = require('./middleware/blp-session');
 import requestHandler = require('./middleware/request-handler');

--- a/lib/subscription/subscription.ts
+++ b/lib/subscription/subscription.ts
@@ -2,13 +2,14 @@
 
 import BAPI = require('../blpapi-wrapper');
 import BufferManager = require('../util/historical-buffer-manager');
+import interfaces = require('../interface');
 
 export = Subscription;
 
-class Subscription extends BAPI.Subscription {
+class Subscription extends BAPI.Subscription implements interfaces.ISubscription {
 
     correlationId: number;
-    buffer: BufferManager<Object> = null;
+    buffer: interfaces.IHistoricalBufferManager<Object> = null;
 
     constructor(cid: number,
                 security: string,

--- a/lib/util/historical-buffer-manager.ts
+++ b/lib/util/historical-buffer-manager.ts
@@ -24,7 +24,7 @@ class Buffer<T> {
 export = HistoricalBufferManager;
 
 // This class creates a buffer manager which manage N buffers(N is taken from constructor parameter)
-class HistoricalBufferManager<T> {
+class HistoricalBufferManager<T> implements interfaces.IHistoricalBufferManager<T> {
 
     // PRIVATE VARIABLES
     private _buffers: Buffer<T>[] = [];

--- a/lib/util/map.ts
+++ b/lib/util/map.ts
@@ -1,10 +1,11 @@
 /// <reference path='../../typings/tsd.d.ts' />
 
 import _ = require('lodash');
+import interfaces = require('../interface');
 
 export = Map;
 
-class Map<T> {
+class Map<T> implements interfaces.IMap<T> {
     private _size: number = 0;
     protected _map: {[key: string]: T} = {};
 

--- a/lib/websocket/websocket-handler.ts
+++ b/lib/websocket/websocket-handler.ts
@@ -23,6 +23,8 @@ type SubscriptionOption = {
     options?: any;
 }
 
+type ISubscription = Interface.ISubscription;
+
 // GLOBAL
 var LOGGER: bunyan.Logger = bunyan.createLogger(conf.get('loggerOptions'));
 
@@ -40,8 +42,8 @@ export function wsOnConnect(s: webSocket): void
 }
 
 // PRIVATE FUNCTIONS
-function getCorrelationIds(subscriptions: Subscription[]): number[] {
-    return subscriptions.map((s: Subscription): number => {
+function getCorrelationIds(subscriptions: ISubscription[]): number[] {
+    return subscriptions.map((s: ISubscription): number => {
         return s.correlationId;
     });
 }
@@ -64,8 +66,8 @@ function onConnect(socket: Interface.ISocket): void
         });
 
     // Create subscriptions store
-    var activeSubscriptions = new Map<Subscription>();
-    var receivedSubscriptions = new Map<Subscription>();
+    var activeSubscriptions = new Map<ISubscription>();
+    var receivedSubscriptions = new Map<ISubscription>();
 
     blpSocketSession.then((socket: Interface.ISocket): void => {
         // Clean up sockets for cases where the underlying session terminated unexpectedly
@@ -125,7 +127,7 @@ function onConnect(socket: Interface.ISocket): void
         }
 
         // Create Subscription object array and add event listeners
-        var subscriptions = _.map(data, (s: SubscriptionOption): Subscription => {
+        var subscriptions = _.map(data, (s: SubscriptionOption): ISubscription => {
             var sub = new Subscription(s.correlationId,
                                        s.security,
                                        s.fields,
@@ -161,7 +163,7 @@ function onConnect(socket: Interface.ISocket): void
             // TODO: Support authorized identity.
             socket.blpSession.subscribe(subscriptions, undefined).then((): void => {
                 if (socket.isConnected()) {
-                    subscriptions.forEach((s: Subscription): void => {
+                    subscriptions.forEach((s: ISubscription): void => {
                         activeSubscriptions.set(s.correlationId, s);
                     });
                     socket.log.debug('Subscribed');
@@ -194,7 +196,7 @@ function onConnect(socket: Interface.ISocket): void
             return;
         }
 
-        var subscriptions: Subscription[] = [];
+        var subscriptions: ISubscription[] = [];
 
         if (!data) {
             // If no correlation Id specified
@@ -240,14 +242,14 @@ function onConnect(socket: Interface.ISocket): void
         socket.log.info('Client disconnected.');
     });
 
-    function remove(s: Subscription): void
+    function remove(s: ISubscription): void
     {
         s.removeAllListeners();
         activeSubscriptions.delete(s.correlationId);
         receivedSubscriptions.delete(s.correlationId);
     }
 
-    function unsubscribe(subscriptions: Subscription[],
+    function unsubscribe(subscriptions: ISubscription[],
                          notify: boolean = false): void
     {
         blpSocketSession.then((socket: Interface.ISocket): void => {


### PR DESCRIPTION
This PR changes the dependencies a bit so `interface.ts` becomes leaf node. It also tries to use interfaces as type definition rather than the concrete implementation. The following graph shows the dependencies after this change. This PR closes #150 .

![test](https://cloud.githubusercontent.com/assets/3301112/6813952/4a680526-d237-11e4-9647-82bab71ae4cc.png)
