### PR TITLE
Constrain TypeScript version to allow only for patch-level changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "socket.io-client": "^1.3.4",
     "tsd": "^0.5.7",
     "tslint": "^2.1.1",
-    "typescript": "^1.4.1"
+    "typescript": "~1.4.1"
   },
   "scripts": {
     "test": "make check"


### PR DESCRIPTION
Due to issue #152, his constrains TypeScript to >= 1.4.1, < 1.5.0.  It
turns out that from npm v1 => v2, there was a change in `semver` in how
caret (i.e., ^) handles preleases that changed.  Since it appears that
TypeScript has breaking changes between minor versions, we need to be
more restrictive on version constraints for `typescript`.
