### PR TITLE
Constrain tslint version to allow only patch-level changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "should": "^5.0.1",
     "socket.io-client": "^1.3.4",
     "tsd": "^0.5.7",
-    "tslint": "^2.1.1",
+    "tslint": "~2.1.1",
     "typescript": "~1.4.1"
   },
   "scripts": {


### PR DESCRIPTION
On npm v1, we would pick up 2.2.0-beta which is apparently not
backwards compatible with 2.1.x.

Fixes #160.
