### PR TITLE
Fix cmd line in MarketDataSubscription_LongPoll.js

### DIFF
--- a/examples/node/MarketDataSubscription_LongPoll.js
+++ b/examples/node/MarketDataSubscription_LongPoll.js
@@ -1,17 +1,16 @@
 var fs = require('fs');
 var util = require('util');
 var request = require("request");
+var opts = require("./cmdline").parse(); // Parse cmdline options.
 
-var host = process.argv[2] || 'http-api-host';
-var port = 3000;
-var url = 'https://' + host + ':' + port;
-var NUM_REQUEST = 10;   // Number of long-poll requests before unsubscribe
-var counter = 0;
+var url = 'https://' + opts.host + ':' + opts.port;
 var opt = {
     cert: fs.readFileSync('client.crt'),
     key: fs.readFileSync('client.key'),
     ca: fs.readFileSync('bloomberg.crt')
-};
+}
+var NUM_REQUEST = 10; // Number of long-poll requests before unsubscribe.
+var counter = 0;
 
 function subscribe()
 {

--- a/examples/node/MarketDataSubscription_socketio.js
+++ b/examples/node/MarketDataSubscription_socketio.js
@@ -1,8 +1,7 @@
-// usage: node MarketDataSubscription_socketio.js [<host> [<port>]]
-
 var fs = require('fs');
 var util = require('util');
 var io = require('socket.io-client');
+var opts = require('./cmdline').parse(); // Parse cmdline options.
 
 var N_DATA_EVENTS = 2; // Number of subscription data received before unsubscribe
 
@@ -12,12 +11,9 @@ var SUBSCRIPTIONS = [
 ];
 
 // main
-var argv = process.argv.slice(2);
-var host = (argv.length > 0) ? argv[0] : 'http-api-host';
-var port = (argv.length > 1) ? argv[1] : 8081;
 var ns = 'subscription';
+var url = util.format('%s:%s/%s', opts.host, opts.port, ns);
 
-var url = util.format('%s:%s/%s', host, port, ns);
 var opt = {
     secure: true,
     cert: fs.readFileSync('client.crt'),

--- a/examples/node/cmdline.js
+++ b/examples/node/cmdline.js
@@ -1,0 +1,18 @@
+var nomnom = require('nomnom');
+
+exports.parse = function() {
+    return nomnom
+        .option('host', {
+            abbr: 'i',
+            help: 'The Bloomberg API HTTP server hostname',
+            metavar: '<host>',
+            required: true
+        })
+        .option('port', {
+            abbr: 'p',
+            help: 'The Bloomberg API HTTP server port',
+            metavar: '<port>',
+            required: true
+        })
+        .parse();
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "mocha": "^2.1.0",
     "mockery": "^1.4.0",
+    "nomnom": "^1.8.1",
     "request": "2.53.0",
     "should": "^5.0.1",
     "socket.io-client": "^1.3.4",


### PR DESCRIPTION
Example MarketDataSubscription_LongPoll.js doesn't offer any command
line arguments support. Only host can be defined, but to actually see
how, it is necessary to look into the code. Port can't be redefined
from command line. After these problems are fixed it would be nice to
have --help option making it easier to discover how to pass options.

Closes #162
