### PR TITLE
Fixed bug in blpapi-wrapper.ts for Intraday

### DIFF
--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -76,7 +76,7 @@ var EVENT_TYPE = {
 var REQUEST_TO_RESPONSE_MAP: { [index: string]: string; } = {
     // //blp/refdata
     'HistoricalDataRequest': 'HistoricalDataResponse',
-    'IntradayTickRequest':   'IntradayTickResponse',  
+    'IntradayTickRequest':   'IntradayTickResponse',
     'IntradayBarRequest':    'IntradayBarResponse',
     'ReferenceDataRequest':  'ReferenceDataResponse',
     'PortfolioDataRequest':  'PortfolioDataResponse',

--- a/lib/blpapi-wrapper.ts
+++ b/lib/blpapi-wrapper.ts
@@ -76,8 +76,8 @@ var EVENT_TYPE = {
 var REQUEST_TO_RESPONSE_MAP: { [index: string]: string; } = {
     // //blp/refdata
     'HistoricalDataRequest': 'HistoricalDataResponse',
-    'IntraDayTickRequest':   'IntraDayTickResponse',
-    'IntraDayBarRequest':    'IntraDayBarResponse',
+    'IntradayTickRequest':   'IntradayTickResponse',  
+    'IntradayBarRequest':    'IntradayBarResponse',
     'ReferenceDataRequest':  'ReferenceDataResponse',
     'PortfolioDataRequest':  'PortfolioDataResponse',
     'BeqsRequest':           'BeqsResponse',


### PR DESCRIPTION
BLPAPI Developer's Guide v2.54 (http://www.bloomberglabs.com/api/content/uploads/sites/2/2014/07/blpapi-developers-guide-2.54.pdf) has incorrect capitalization in table A.2 that propagated into blpapi-wrapper.ts. Corrected this in variable REQUEST_TO_RESPONSE_MAP, enabling correct handling of intraday requests.
